### PR TITLE
fix(chart): gate main ClusterRole rules by engine and provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - GCP and OCI simulation providers now handle partial final pagination pages without indexing past the available instances.
 - Non-positive `pageSize` configuration values now emit a warning and use the provider default instead of reaching provider APIs and simulation pagination loops.
 
+### Security
+
+- Main Topograph API server ClusterRole rules are gated by the selected engine and provider: `nodes`, `pods`, `daemonsets`, and `configmaps` permissions render only when the engine or provider reaches the Kubernetes API, and the ClusterRole and ClusterRoleBinding are omitted entirely for non-Kubernetes combinations such as the `test` provider with the `slurm` engine.
+
 ---
 
 ## [v1.0.0] - 2026-08-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Removed unused RBAC verbs from the Topograph API server and node-data-broker ClusterRoles (least-privilege): API server `pods` rule dropped `get` (list-only), `daemonsets` rule dropped `list` (get-only), Slinky receives Node `patch` without Node `update`, and the Slinky `configmaps` rule dropped `list`; node-data-broker `nodes` rule dropped `list` (get/update), and the InfiniBand `daemonsets`/`pods` rules dropped `list`/`get` respectively (get-only, list-only).
 
 - node-observer ClusterRole no longer grants unused `get`; `nodes` list/watch now gated on `trigger.nodeSelector`.
+- Gated the main Topograph API server ClusterRole rules by engine and provider: `nodes`, `pods`, and `daemonsets` permissions are now rendered only when the selected engine or provider requires them, and the ClusterRole and ClusterRoleBinding are omitted entirely for non-Kubernetes combos (e.g. `test` provider + `slurm` engine). `pods/exec` and `configmaps` gates remain unchanged.
 ### Migration (Helm — hardened security context)
 
 The chart's hardened defaults are a breaking change for two deployment shapes; override only the affected keys/component:

--- a/charts/topograph/templates/rbac.yaml
+++ b/charts/topograph/templates/rbac.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.rbac.create -}}
+{{- $engine := .Values.engine.name -}}
+{{- $provider := .Values.provider.name -}}
 {{- /*
 pods/exec is needed by providers that exec inside pods, and by Slinky only for
 legacy partition discovery through `scontrol show partition` in the controller
@@ -6,11 +8,11 @@ pod (falling back to a login pod when present).
 Slinky skips that path when dynamic nodes are enabled or when a topology entry
 already supplies nodes, a pod selector, or the default flat topology.
 */ -}}
-{{- $needsPodExec := dict "value" false -}}
-{{- if eq .Values.provider.name "infiniband-k8s" -}}
-{{- $_ := set $needsPodExec "value" true -}}
+{{- $needsPodExec := false -}}
+{{- if eq $provider "infiniband-k8s" -}}
+{{- $needsPodExec = true -}}
 {{- end -}}
-{{- if eq .Values.engine.name "slinky" -}}
+{{- if eq $engine "slinky" -}}
 {{- $params := default dict .Values.engine.params -}}
 {{- if not (get $params "useDynamicNodes") -}}
 {{- range $topology := (default dict (get $params "topologies")) -}}
@@ -20,41 +22,64 @@ already supplies nodes, a pod selector, or the default flat topology.
 {{- $hasPodSelector := and $podSelector (or (get $podSelector "matchLabels") (get $podSelector "matchExpressions")) -}}
 {{- $isDefaultFlat := and (get $spec "clusterDefault") (eq (get $spec "plugin") "topology/flat") (not (get $spec "partition")) -}}
 {{- if and (not $hasNodes) (not $hasPodSelector) (not $isDefaultFlat) -}}
-{{- $_ := set $needsPodExec "value" true -}}
+{{- $needsPodExec = true -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
+{{- /*
+Gate the main ClusterRole rules by engine/provider. The API server only needs
+Kubernetes API access when the selected engine or provider actually calls the
+API.
+*/ -}}
+{{- $needsNodes := false -}}
+{{- if or (eq $engine "k8s") (eq $engine "slinky") (eq $engine "nfd") (eq $provider "dra") (eq $provider "infiniband-k8s") -}}
+{{- $needsNodes = true -}}
+{{- end -}}
+{{- $needsPods := false -}}
+{{- if or (eq $engine "slinky") (eq $provider "infiniband-k8s") -}}
+{{- $needsPods = true -}}
+{{- end -}}
+{{- $needsDaemonSets := false -}}
+{{- if eq $provider "infiniband-k8s" -}}
+{{- $needsDaemonSets = true -}}
+{{- end -}}
+{{- $needsConfigMaps := false -}}
+{{- if eq $engine "slinky" -}}
+{{- $needsConfigMaps = true -}}
+{{- end -}}
+{{- if or $needsNodes $needsPods $needsDaemonSets $needsConfigMaps $needsPodExec }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "topograph.rbacName" . }}
 rules:
+{{- if $needsPods }}
 - apiGroups: [""]
   resources: [pods]
   verbs: [list]
-{{- if $needsPodExec.value }}
+{{- end }}
+{{- if $needsPodExec }}
 - apiGroups: [""]
   resources: [pods/exec]
   verbs: [create]
 {{- end }}
+{{- if $needsNodes }}
 - apiGroups: [""]
   resources: [nodes]
   verbs: [get,list]
-{{- if eq .Values.engine.name "k8s" }}
+{{- if or (eq $engine "k8s") (eq $engine "slinky") }}
 - apiGroups: [""]
   resources: [nodes]
   verbs: [patch]
 {{- end }}
-{{- if eq .Values.engine.name "slinky" }}
-- apiGroups: [""]
-  resources: [nodes]
-  verbs: [patch]
 {{- end }}
+{{- if $needsDaemonSets }}
 - apiGroups: [apps]
   resources: [daemonsets]
   verbs: [get]
-{{- if eq .Values.engine.name "slinky" }}
+{{- end }}
+{{- if $needsConfigMaps }}
 - apiGroups: [""]
   resources: [configmaps]
   verbs: [create,get,update]
@@ -73,7 +98,8 @@ roleRef:
   kind: ClusterRole
   name: {{ include "topograph.rbacName" . }}
   apiGroup: rbac.authorization.k8s.io
-{{- if eq .Values.engine.name "nfd" }}
+{{- end }}
+{{- if eq $engine "nfd" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/topograph/templates/rbac.yaml
+++ b/charts/topograph/templates/rbac.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.rbac.create -}}
+{{- $engine := .Values.engine.name -}}
+{{- $provider := .Values.provider.name -}}
 {{- /*
 pods/exec is needed by providers that exec inside pods, and by Slinky only for
 legacy partition discovery through `scontrol show partition` in the controller
@@ -6,11 +8,11 @@ pod (falling back to a login pod when present).
 Slinky skips that path when dynamic nodes are enabled or when a topology entry
 already supplies nodes, a pod selector, or the default flat topology.
 */ -}}
-{{- $needsPodExec := dict "value" false -}}
-{{- if eq .Values.provider.name "infiniband-k8s" -}}
-{{- $_ := set $needsPodExec "value" true -}}
+{{- $needsPodExec := false -}}
+{{- if eq $provider "infiniband-k8s" -}}
+{{- $needsPodExec = true -}}
 {{- end -}}
-{{- if eq .Values.engine.name "slinky" -}}
+{{- if eq $engine "slinky" -}}
 {{- $params := default dict .Values.engine.params -}}
 {{- if not (get $params "useDynamicNodes") -}}
 {{- range $topology := (default dict (get $params "topologies")) -}}
@@ -20,41 +22,74 @@ already supplies nodes, a pod selector, or the default flat topology.
 {{- $hasPodSelector := and $podSelector (or (get $podSelector "matchLabels") (get $podSelector "matchExpressions")) -}}
 {{- $isDefaultFlat := and (get $spec "clusterDefault") (eq (get $spec "plugin") "topology/flat") (not (get $spec "partition")) -}}
 {{- if and (not $hasNodes) (not $hasPodSelector) (not $isDefaultFlat) -}}
-{{- $_ := set $needsPodExec "value" true -}}
+{{- $needsPodExec = true -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
+{{- /*
+Gate the main ClusterRole rules by engine/provider. The API server only needs
+Kubernetes API access when the selected engine or provider actually calls the
+API.
+*/ -}}
+{{- $needsNodeList := false -}}
+{{- if or (eq $engine "k8s") (eq $engine "slinky") (eq $engine "nfd") (eq $provider "dra") (eq $provider "infiniband-k8s") -}}
+{{- $needsNodeList = true -}}
+{{- end -}}
+{{- $needsNodeWrite := false -}}
+{{- if or (eq $engine "k8s") (and (eq $engine "slinky") (get (default dict .Values.engine.params) "useDynamicNodes")) -}}
+{{- $needsNodeWrite = true -}}
+{{- end -}}
+{{- $needsPods := false -}}
+{{- if or (eq $engine "slinky") (eq $provider "infiniband-k8s") -}}
+{{- $needsPods = true -}}
+{{- end -}}
+{{- $needsDaemonSets := false -}}
+{{- if eq $provider "infiniband-k8s" -}}
+{{- $needsDaemonSets = true -}}
+{{- end -}}
+{{- $needsConfigMaps := false -}}
+{{- if eq $engine "slinky" -}}
+{{- $needsConfigMaps = true -}}
+{{- end -}}
+{{- $hasMainRules := or $needsNodeList $needsNodeWrite $needsPods $needsDaemonSets $needsConfigMaps $needsPodExec -}}
+{{- if $hasMainRules }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "topograph.rbacName" . }}
 rules:
+{{- if $needsPods }}
 - apiGroups: [""]
   resources: [pods]
   verbs: [list]
-{{- if $needsPodExec.value }}
+{{- end }}
+{{- if $needsPodExec }}
 - apiGroups: [""]
   resources: [pods/exec]
   verbs: [create]
 {{- end }}
+{{- if or $needsNodeList $needsNodeWrite }}
 - apiGroups: [""]
   resources: [nodes]
   verbs: [get,list]
-{{- if eq .Values.engine.name "k8s" }}
+{{- if eq $engine "k8s" }}
 - apiGroups: [""]
   resources: [nodes]
   verbs: [update]
 {{- end }}
-{{- if eq .Values.engine.name "slinky" }}
+{{- if eq $engine "slinky" }}
 - apiGroups: [""]
   resources: [nodes]
   verbs: [patch]
 {{- end }}
+{{- end }}
+{{- if $needsDaemonSets }}
 - apiGroups: [apps]
   resources: [daemonsets]
   verbs: [get]
-{{- if eq .Values.engine.name "slinky" }}
+{{- end }}
+{{- if $needsConfigMaps }}
 - apiGroups: [""]
   resources: [configmaps]
   verbs: [create,get,update]
@@ -73,7 +108,8 @@ roleRef:
   kind: ClusterRole
   name: {{ include "topograph.rbacName" . }}
   apiGroup: ""
-{{- if eq .Values.engine.name "nfd" }}
+{{- end }}
+{{- if eq $engine "nfd" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -93,7 +129,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ include "topograph.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{.Release.Namespace}}
   apiGroup: ""
 roleRef:
   kind: Role

--- a/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
+++ b/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
@@ -1,13 +1,6 @@
 renders default values.yaml:
   1: |
-    raw: |
-      1. Get the application URL by running these commands:
-        export POD_NAME=$(kubectl get pods --namespace topograph -l "app.kubernetes.io/name=topograph,app.kubernetes.io/instance=chart-ci" -o jsonpath="{.items[0].metadata.name}")
-        export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-        echo "Visit http://127.0.0.1:8080 to use your application"
-        kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT
-
-        NOTE: node-data-broker applies node annotations once when each broker pod starts.
+    raw: "1. Get the application URL by running these commands:\r\n  export POD_NAME=$(kubectl get pods --namespace topograph -l \"app.kubernetes.io/name=topograph,app.kubernetes.io/instance=chart-ci\" -o jsonpath=\"{.items[0].metadata.name}\")\r\n  export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath=\"{.spec.containers[0].ports[0].containerPort}\")\r\n  echo \"Visit http://127.0.0.1:8080 to use your application\"\r\n  kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT\r\n\r\n  NOTE: node-data-broker applies node annotations once when each broker pod starts.\r\n"
   2: |
     apiVersion: v1
     data:
@@ -47,7 +40,7 @@ renders default values.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
+            checksum/config: b883071c84f7fede8c950dc81c66e785e4e0516bf51254a1402be5ac099bd90c
           labels:
             app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
@@ -281,7 +274,7 @@ renders default values.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: ce1893e4c0757528265ccc6126f8267f7dcfab70208b237990c5fc187c3bc453
+            checksum/config: 3092fdbac1a10f06f89cfa76221d2c6e9d7e244e14af2d67c850e2d22e723593
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -388,12 +381,6 @@ renders default values.yaml:
       - apiGroups:
           - ""
         resources:
-          - pods
-        verbs:
-          - list
-      - apiGroups:
-          - ""
-        resources:
           - nodes
         verbs:
           - get
@@ -404,12 +391,6 @@ renders default values.yaml:
           - nodes
         verbs:
           - update
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - get
   14: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -548,14 +529,7 @@ renders default values.yaml:
           type: RuntimeDefault
 renders values.k8s.gateway-api-example.yaml:
   1: |
-    raw: |
-      1. Get the application URL by running these commands:
-        http://topograph.example.com/
-        NOTE: The above URL(s) resolve to the Gateway referenced by parentRefs.
-              The Gateway is platform-owned; confirm the operator has provisioned
-              it and (if needed) published its listener address in DNS.
-
-        NOTE: node-data-broker applies node annotations once when each broker pod starts.
+    raw: "1. Get the application URL by running these commands:\r\n  http://topograph.example.com/\r\n  NOTE: The above URL(s) resolve to the Gateway referenced by parentRefs.\r\n        The Gateway is platform-owned; confirm the operator has provisioned\r\n        it and (if needed) published its listener address in DNS.\r\n\r\n  NOTE: node-data-broker applies node annotations once when each broker pod starts.\r\n"
   2: |
     apiVersion: v1
     data:
@@ -595,7 +569,7 @@ renders values.k8s.gateway-api-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
+            checksum/config: b883071c84f7fede8c950dc81c66e785e4e0516bf51254a1402be5ac099bd90c
           labels:
             app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
@@ -851,7 +825,7 @@ renders values.k8s.gateway-api-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: ce1893e4c0757528265ccc6126f8267f7dcfab70208b237990c5fc187c3bc453
+            checksum/config: 3092fdbac1a10f06f89cfa76221d2c6e9d7e244e14af2d67c850e2d22e723593
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -958,12 +932,6 @@ renders values.k8s.gateway-api-example.yaml:
       - apiGroups:
           - ""
         resources:
-          - pods
-        verbs:
-          - list
-      - apiGroups:
-          - ""
-        resources:
           - nodes
         verbs:
           - get
@@ -974,12 +942,6 @@ renders values.k8s.gateway-api-example.yaml:
           - nodes
         verbs:
           - update
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - get
   15: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -1118,14 +1080,7 @@ renders values.k8s.gateway-api-example.yaml:
           type: RuntimeDefault
 renders values.k8s.gcp-federated-workload-identity-example.yaml:
   1: |
-    raw: |
-      1. Get the application URL by running these commands:
-        export POD_NAME=$(kubectl get pods --namespace topograph -l "app.kubernetes.io/name=topograph,app.kubernetes.io/instance=chart-ci" -o jsonpath="{.items[0].metadata.name}")
-        export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-        echo "Visit http://127.0.0.1:8080 to use your application"
-        kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT
-
-        NOTE: node-data-broker applies node annotations once when each broker pod starts.
+    raw: "1. Get the application URL by running these commands:\r\n  export POD_NAME=$(kubectl get pods --namespace topograph -l \"app.kubernetes.io/name=topograph,app.kubernetes.io/instance=chart-ci\" -o jsonpath=\"{.items[0].metadata.name}\")\r\n  export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath=\"{.spec.containers[0].ports[0].containerPort}\")\r\n  echo \"Visit http://127.0.0.1:8080 to use your application\"\r\n  kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT\r\n\r\n  NOTE: node-data-broker applies node annotations once when each broker pod starts.\r\n"
   2: |
     apiVersion: v1
     data:
@@ -1165,7 +1120,7 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
+            checksum/config: b883071c84f7fede8c950dc81c66e785e4e0516bf51254a1402be5ac099bd90c
           labels:
             app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
@@ -1424,7 +1379,7 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: ab9e684e4fe6d8559973e231b610449f5fcb157903352e7d217b7624a7f7f4a1
+            checksum/config: 0f9b5d3fe62c69990082ad5c6fd50c16c218fb60f01bab1e50eeaa2146bb2c54
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -1538,12 +1493,6 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
       - apiGroups:
           - ""
         resources:
-          - pods
-        verbs:
-          - list
-      - apiGroups:
-          - ""
-        resources:
           - nodes
         verbs:
           - get
@@ -1554,12 +1503,6 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
           - nodes
         verbs:
           - update
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - get
   14: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -1698,14 +1641,7 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
           type: RuntimeDefault
 renders values.k8s.gcp-service-account-example.yaml:
   1: |
-    raw: |
-      1. Get the application URL by running these commands:
-        export POD_NAME=$(kubectl get pods --namespace topograph -l "app.kubernetes.io/name=topograph,app.kubernetes.io/instance=chart-ci" -o jsonpath="{.items[0].metadata.name}")
-        export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-        echo "Visit http://127.0.0.1:8080 to use your application"
-        kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT
-
-        NOTE: node-data-broker applies node annotations once when each broker pod starts.
+    raw: "1. Get the application URL by running these commands:\r\n  export POD_NAME=$(kubectl get pods --namespace topograph -l \"app.kubernetes.io/name=topograph,app.kubernetes.io/instance=chart-ci\" -o jsonpath=\"{.items[0].metadata.name}\")\r\n  export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath=\"{.spec.containers[0].ports[0].containerPort}\")\r\n  echo \"Visit http://127.0.0.1:8080 to use your application\"\r\n  kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT\r\n\r\n  NOTE: node-data-broker applies node annotations once when each broker pod starts.\r\n"
   2: |
     apiVersion: v1
     data:
@@ -1745,7 +1681,7 @@ renders values.k8s.gcp-service-account-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
+            checksum/config: b883071c84f7fede8c950dc81c66e785e4e0516bf51254a1402be5ac099bd90c
           labels:
             app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
@@ -1992,7 +1928,7 @@ renders values.k8s.gcp-service-account-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 34b5154f7f45009200945b31fc5a82f2c81e895c842cb7263f22fb0510e24dd0
+            checksum/config: fb962b8f4a280e77bd0363989948b0ebf3b5e02cfa51a8cdb39bf8c74616250f
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -2106,12 +2042,6 @@ renders values.k8s.gcp-service-account-example.yaml:
       - apiGroups:
           - ""
         resources:
-          - pods
-        verbs:
-          - list
-      - apiGroups:
-          - ""
-        resources:
           - nodes
         verbs:
           - get
@@ -2122,12 +2052,6 @@ renders values.k8s.gcp-service-account-example.yaml:
           - nodes
         verbs:
           - update
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - get
   14: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -2266,14 +2190,7 @@ renders values.k8s.gcp-service-account-example.yaml:
           type: RuntimeDefault
 renders values.k8s.ib-example.yaml:
   1: |
-    raw: |
-      1. Get the application URL by running these commands:
-        export POD_NAME=$(kubectl get pods --namespace topograph -l "app.kubernetes.io/name=topograph,app.kubernetes.io/instance=chart-ci" -o jsonpath="{.items[0].metadata.name}")
-        export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-        echo "Visit http://127.0.0.1:8080 to use your application"
-        kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT
-
-        NOTE: node-data-broker applies node annotations once when each broker pod starts.
+    raw: "1. Get the application URL by running these commands:\r\n  export POD_NAME=$(kubectl get pods --namespace topograph -l \"app.kubernetes.io/name=topograph,app.kubernetes.io/instance=chart-ci\" -o jsonpath=\"{.items[0].metadata.name}\")\r\n  export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath=\"{.spec.containers[0].ports[0].containerPort}\")\r\n  echo \"Visit http://127.0.0.1:8080 to use your application\"\r\n  kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT\r\n\r\n  NOTE: node-data-broker applies node annotations once when each broker pod starts.\r\n"
   2: |
     apiVersion: v1
     data:
@@ -2313,7 +2230,7 @@ renders values.k8s.ib-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
+            checksum/config: b883071c84f7fede8c950dc81c66e785e4e0516bf51254a1402be5ac099bd90c
           labels:
             app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
@@ -2562,7 +2479,7 @@ renders values.k8s.ib-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 12ded19ccdc256a879be87750e73e8df0458ba73f2df1995312e94f790dedfd5
+            checksum/config: 4c1e4c894da2afd40441c5103387fdcd4ba8ef6e962bf70f935580b026870322
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -2842,14 +2759,7 @@ renders values.k8s.ib-example.yaml:
           type: RuntimeDefault
 renders values.slinky.block-example.yaml:
   1: |
-    raw: |
-      1. Get the application URL by running these commands:
-        export POD_NAME=$(kubectl get pods --namespace topograph -l "app.kubernetes.io/name=topograph,app.kubernetes.io/instance=chart-ci" -o jsonpath="{.items[0].metadata.name}")
-        export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-        echo "Visit http://127.0.0.1:8080 to use your application"
-        kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT
-
-        NOTE: node-data-broker applies node annotations once when each broker pod starts.
+    raw: "1. Get the application URL by running these commands:\r\n  export POD_NAME=$(kubectl get pods --namespace topograph -l \"app.kubernetes.io/name=topograph,app.kubernetes.io/instance=chart-ci\" -o jsonpath=\"{.items[0].metadata.name}\")\r\n  export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath=\"{.spec.containers[0].ports[0].containerPort}\")\r\n  echo \"Visit http://127.0.0.1:8080 to use your application\"\r\n  kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT\r\n\r\n  NOTE: node-data-broker applies node annotations once when each broker pod starts.\r\n"
   2: |
     apiVersion: v1
     data:
@@ -2889,7 +2799,7 @@ renders values.slinky.block-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
+            checksum/config: b883071c84f7fede8c950dc81c66e785e4e0516bf51254a1402be5ac099bd90c
           labels:
             app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
@@ -3145,7 +3055,7 @@ renders values.slinky.block-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 7e2d3da5fcebb1ad73540cdeea400e6b5b3580c427dae006587cc40c46c31b01
+            checksum/config: b29ce3501bf8557a027122aed8a93e928e834c127248ca566e8c98debb2278a9
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -3270,12 +3180,6 @@ renders values.slinky.block-example.yaml:
           - nodes
         verbs:
           - patch
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - get
       - apiGroups:
           - ""
         resources:
@@ -3422,14 +3326,7 @@ renders values.slinky.block-example.yaml:
           type: RuntimeDefault
 renders values.slinky.partition-example.yaml:
   1: |
-    raw: |
-      1. Get the application URL by running these commands:
-        export POD_NAME=$(kubectl get pods --namespace topograph -l "app.kubernetes.io/name=topograph,app.kubernetes.io/instance=chart-ci" -o jsonpath="{.items[0].metadata.name}")
-        export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-        echo "Visit http://127.0.0.1:8080 to use your application"
-        kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT
-
-        NOTE: node-data-broker applies node annotations once when each broker pod starts.
+    raw: "1. Get the application URL by running these commands:\r\n  export POD_NAME=$(kubectl get pods --namespace topograph -l \"app.kubernetes.io/name=topograph,app.kubernetes.io/instance=chart-ci\" -o jsonpath=\"{.items[0].metadata.name}\")\r\n  export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath=\"{.spec.containers[0].ports[0].containerPort}\")\r\n  echo \"Visit http://127.0.0.1:8080 to use your application\"\r\n  kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT\r\n\r\n  NOTE: node-data-broker applies node annotations once when each broker pod starts.\r\n"
   2: |
     apiVersion: v1
     data:
@@ -3469,7 +3366,7 @@ renders values.slinky.partition-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
+            checksum/config: b883071c84f7fede8c950dc81c66e785e4e0516bf51254a1402be5ac099bd90c
           labels:
             app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
@@ -3742,7 +3639,7 @@ renders values.slinky.partition-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 665f27c8c6095b211f8df2f68171dbe62731459459aaf3f4e5170c49ea98ab25
+            checksum/config: a48f9f8dcd12a6cf1930aeb69af5ad24e61e6a3b72624ea75f0f4f0d4d8f5055
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -3867,12 +3764,6 @@ renders values.slinky.partition-example.yaml:
           - nodes
         verbs:
           - patch
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - get
       - apiGroups:
           - ""
         resources:
@@ -4019,14 +3910,7 @@ renders values.slinky.partition-example.yaml:
           type: RuntimeDefault
 renders values.slinky.tree-example.yaml:
   1: |
-    raw: |
-      1. Get the application URL by running these commands:
-        export POD_NAME=$(kubectl get pods --namespace topograph -l "app.kubernetes.io/name=topograph,app.kubernetes.io/instance=chart-ci" -o jsonpath="{.items[0].metadata.name}")
-        export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-        echo "Visit http://127.0.0.1:8080 to use your application"
-        kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT
-
-        NOTE: node-data-broker applies node annotations once when each broker pod starts.
+    raw: "1. Get the application URL by running these commands:\r\n  export POD_NAME=$(kubectl get pods --namespace topograph -l \"app.kubernetes.io/name=topograph,app.kubernetes.io/instance=chart-ci\" -o jsonpath=\"{.items[0].metadata.name}\")\r\n  export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath=\"{.spec.containers[0].ports[0].containerPort}\")\r\n  echo \"Visit http://127.0.0.1:8080 to use your application\"\r\n  kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT\r\n\r\n  NOTE: node-data-broker applies node annotations once when each broker pod starts.\r\n"
   2: |
     apiVersion: v1
     data:
@@ -4066,7 +3950,7 @@ renders values.slinky.tree-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
+            checksum/config: b883071c84f7fede8c950dc81c66e785e4e0516bf51254a1402be5ac099bd90c
           labels:
             app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
@@ -4314,7 +4198,7 @@ renders values.slinky.tree-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 5828aa0fcd7ba3f91e124680c8825c4fa19617f126dd4a459666249ef947ec85
+            checksum/config: 7e2eae85827a85b2e4f728dd00bad33ff9d16abf90cab4f3605bd0f6fe70bacc
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -4439,12 +4323,6 @@ renders values.slinky.tree-example.yaml:
           - nodes
         verbs:
           - patch
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - get
       - apiGroups:
           - ""
         resources:

--- a/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
+++ b/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
@@ -416,12 +416,6 @@ renders default values.yaml:
       - apiGroups:
           - ""
         resources:
-          - pods
-        verbs:
-          - list
-      - apiGroups:
-          - ""
-        resources:
           - nodes
         verbs:
           - get
@@ -432,12 +426,6 @@ renders default values.yaml:
           - nodes
         verbs:
           - patch
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - get
   15: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -1014,12 +1002,6 @@ renders values.k8s.gateway-api-example.yaml:
       - apiGroups:
           - ""
         resources:
-          - pods
-        verbs:
-          - list
-      - apiGroups:
-          - ""
-        resources:
           - nodes
         verbs:
           - get
@@ -1030,12 +1012,6 @@ renders values.k8s.gateway-api-example.yaml:
           - nodes
         verbs:
           - patch
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - get
   16: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -1626,12 +1602,6 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
       - apiGroups:
           - ""
         resources:
-          - pods
-        verbs:
-          - list
-      - apiGroups:
-          - ""
-        resources:
           - nodes
         verbs:
           - get
@@ -1642,12 +1612,6 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
           - nodes
         verbs:
           - patch
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - get
   15: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -2224,12 +2188,6 @@ renders values.k8s.gcp-service-account-example.yaml:
       - apiGroups:
           - ""
         resources:
-          - pods
-        verbs:
-          - list
-      - apiGroups:
-          - ""
-        resources:
           - nodes
         verbs:
           - get
@@ -2240,12 +2198,6 @@ renders values.k8s.gcp-service-account-example.yaml:
           - nodes
         verbs:
           - patch
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - get
   15: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -3456,12 +3408,6 @@ renders values.slinky.block-example.yaml:
         verbs:
           - patch
       - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - get
-      - apiGroups:
           - ""
         resources:
           - configmaps
@@ -4081,12 +4027,6 @@ renders values.slinky.partition-example.yaml:
         verbs:
           - patch
       - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - get
-      - apiGroups:
           - ""
         resources:
           - configmaps
@@ -4680,12 +4620,6 @@ renders values.slinky.tree-example.yaml:
           - nodes
         verbs:
           - patch
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - get
       - apiGroups:
           - ""
         resources:

--- a/charts/topograph/tests/rbac_test.yaml
+++ b/charts/topograph/tests/rbac_test.yaml
@@ -5,7 +5,7 @@ release:
   name: chart-ci
   namespace: topograph
 tests:
-  - it: renders a ClusterRole and ClusterRoleBinding by default
+  - it: renders a ClusterRole and ClusterRoleBinding for the Kubernetes engine by default
     asserts:
       - hasDocuments:
           count: 2
@@ -16,7 +16,15 @@ tests:
           of: ClusterRoleBinding
         documentIndex: 1
 
-  - it: still renders for an existing service account
+  - it: is omitted entirely when rbac.create is false
+    set:
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: still renders for an existing service account with Kubernetes engine
     set:
       serviceAccount:
         create: false
@@ -41,17 +49,104 @@ tests:
           value: existing-topograph-sa
         documentIndex: 1
 
-  - it: is omitted entirely when rbac.create is false
+  - it: grants node read/write for the k8s engine
     set:
-      rbac:
-        create: false
-    asserts:
-      - hasDocuments:
-          count: 0
-
-  - it: grants core node and pod read access by default
+      provider:
+        name: test
+      engine:
+        name: k8s
     documentIndex: 0
     asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [update]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [list]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [patch]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [apps]
+            resources: [daemonsets]
+            verbs: [get]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [configmaps]
+            verbs: [create, get, update]
+
+  - it: grants node read for the dra provider
+    set:
+      provider:
+        name: dra
+      engine:
+        name: slurm
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [update]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [patch]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [list]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [apps]
+            resources: [daemonsets]
+            verbs: [get]
+
+  - it: grants node, pod, and daemonset access for the infiniband-k8s provider
+    set:
+      provider:
+        name: infiniband-k8s
+      engine:
+        name: slurm
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list]
       - contains:
           path: rules
           content:
@@ -62,14 +157,8 @@ tests:
           path: rules
           content:
             apiGroups: [""]
-            resources: [nodes]
-            verbs: [get, list]
-      - contains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [nodes]
-            verbs: [update]
+            resources: [pods/exec]
+            verbs: [create]
       - contains:
           path: rules
           content:
@@ -77,16 +166,31 @@ tests:
             resources: [daemonsets]
             verbs: [get]
 
-  - it: does not grant provider- or engine-specific access by default
+  - it: grants node read, pod read, node patch, and configmap access for the slinky engine
+    set:
+      engine:
+        name: slinky
     documentIndex: 0
     asserts:
-      - notContains:
+      - contains:
           path: rules
           content:
             apiGroups: [""]
-            resources: [pods/exec]
-            verbs: [create]
-      - notContains:
+            resources: [nodes]
+            verbs: [get, list]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [patch]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [list]
+      - contains:
           path: rules
           content:
             apiGroups: [""]
@@ -95,125 +199,69 @@ tests:
       - notContains:
           path: rules
           content:
-            apiGroups: [nfd.k8s-sigs.io]
-            resources: [nodefeatures, nodefeaturegroups]
-            verbs: [create, list, patch, delete]
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [update]
       - notContains:
           path: rules
           content:
             apiGroups: [""]
-            resources: [pods]
-            verbs: [get, list]
+            resources: [pods/exec]
+            verbs: [create]
       - notContains:
           path: rules
           content:
             apiGroups: [apps]
             resources: [daemonsets]
-            verbs: [get, list]
+            verbs: [get]
 
-  - it: grants pods/exec for the infiniband-k8s provider
+  - it: grants node read, node patch, pod read, and configmap access for slinky with dynamic nodes
     set:
-      provider:
-        name: infiniband-k8s
+      engine:
+        name: slinky
+        params:
+          useDynamicNodes: true
     documentIndex: 0
     asserts:
       - contains:
           path: rules
           content:
             apiGroups: [""]
-            resources: [pods/exec]
-            verbs: [create]
-
-  - it: grants configmaps for the slinky engine
-    set:
-      engine:
-        name: slinky
-    documentIndex: 0
-    asserts:
+            resources: [nodes]
+            verbs: [get, list]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [patch]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [list]
       - contains:
           path: rules
           content:
             apiGroups: [""]
             resources: [configmaps]
             verbs: [create, get, update]
-      - notContains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [configmaps]
-            verbs: [create, get, list, update]
-      - contains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [nodes]
-            verbs: [patch]
 
-  - it: does not grant node patch access to non-slinky engines
-    set:
-      engine:
-        name: k8s
-    documentIndex: 0
-    asserts:
-      - notContains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [nodes]
-            verbs: [patch]
-      - contains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [nodes]
-            verbs: [update]
-
-  - it: does not grant node update access to the slinky engine
-    set:
-      engine:
-        name: slinky
-    documentIndex: 0
-    asserts:
-      - contains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [nodes]
-            verbs: [get, list]
-      - contains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [nodes]
-            verbs: [patch]
-      - notContains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [nodes]
-            verbs: [update]
-
-  - it: does not render NFD namespace RBAC for an explicit non-NFD engine
-    set:
-      engine:
-        name: slinky
-    asserts:
-      - hasDocuments:
-          count: 2
-      - isKind:
-          of: ClusterRole
-        documentIndex: 0
-      - isKind:
-          of: ClusterRoleBinding
-        documentIndex: 1
-
-  - it: grants NFD CR access for the nfd engine
+  - it: grants node read for the nfd engine
     set:
       engine:
         name: nfd
     asserts:
       - hasDocuments:
           count: 4
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list]
+        documentIndex: 0
       - notContains:
           path: rules
           content:
@@ -317,6 +365,9 @@ tests:
             verbs: [create]
 
   - it: binds the ClusterRole to the service account in the release namespace
+    set:
+      engine:
+        name: k8s
     documentIndex: 1
     asserts:
       - equal:
@@ -328,3 +379,37 @@ tests:
       - equal:
           path: subjects[0].namespace
           value: topograph
+
+  - it: does not grant provider- or engine-specific access for non-Kubernetes combos
+    set:
+      provider:
+        name: test
+      engine:
+        name: slurm
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render NFD namespace RBAC for an explicit non-NFD engine
+    set:
+      engine:
+        name: slinky
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ClusterRole
+        documentIndex: 0
+      - isKind:
+          of: ClusterRoleBinding
+        documentIndex: 1
+
+  - it: omits the main ClusterRole and ClusterRoleBinding for non-Kubernetes combos
+    set:
+      provider:
+        name: test
+      engine:
+        name: slurm
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/topograph/tests/rbac_test.yaml
+++ b/charts/topograph/tests/rbac_test.yaml
@@ -62,15 +62,9 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: grants core node and pod read access by default
+  - it: grants core node read/write access by default
     documentIndex: 0
     asserts:
-      - contains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [pods]
-            verbs: [list]
       - contains:
           path: rules
           content:
@@ -83,12 +77,6 @@ tests:
             apiGroups: [""]
             resources: [nodes]
             verbs: [patch]
-      - contains:
-          path: rules
-          content:
-            apiGroups: [apps]
-            resources: [daemonsets]
-            verbs: [get]
 
   - it: does not grant provider- or engine-specific access by default
     documentIndex: 0
@@ -120,11 +108,56 @@ tests:
       - notContains:
           path: rules
           content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [list]
+      - notContains:
+          path: rules
+          content:
             apiGroups: [apps]
             resources: [daemonsets]
             verbs: [get, list]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [apps]
+            resources: [daemonsets]
+            verbs: [get]
 
-  - it: grants pods/exec for the infiniband-k8s provider
+  - it: grants node read without node write for the dra provider
+    set:
+      provider:
+        name: dra
+      engine:
+        name: slurm
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [patch]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [list]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [apps]
+            resources: [daemonsets]
+            verbs: [get]
+
+  - it: grants pods, daemonsets, and pods/exec for the infiniband-k8s provider
     set:
       provider:
         name: infiniband-k8s
@@ -136,8 +169,20 @@ tests:
             apiGroups: [""]
             resources: [pods/exec]
             verbs: [create]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [list]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [apps]
+            resources: [daemonsets]
+            verbs: [get]
 
-  - it: grants configmaps for the slinky engine
+  - it: grants configmaps and pods for the slinky engine
     set:
       engine:
         name: slinky
@@ -161,6 +206,18 @@ tests:
             apiGroups: [""]
             resources: [nodes]
             verbs: [patch]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [list]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [apps]
+            resources: [daemonsets]
+            verbs: [get]
 
   - it: grants node patch access to the k8s engine
     set:
@@ -181,18 +238,32 @@ tests:
             resources: [nodes]
             verbs: [update]
 
-  - it: does not grant node patch access to the slurm engine
+  - it: omits the ClusterRole and ClusterRoleBinding for a non-Kubernetes combo
     set:
+      provider:
+        name: test
       engine:
         name: slurm
-    documentIndex: 0
     asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: still renders the ClusterRole for the slurm engine with a Kubernetes provider
+    set:
+      provider:
+        name: infiniband-k8s
+      engine:
+        name: slurm
+    asserts:
+      - hasDocuments:
+          count: 2
       - notContains:
           path: rules
           content:
             apiGroups: [""]
             resources: [nodes]
             verbs: [patch]
+        documentIndex: 0
 
   - it: does not grant node update access to the slinky engine
     set:
@@ -253,6 +324,20 @@ tests:
             apiGroups: [""]
             resources: [nodes]
             verbs: [patch]
+        documentIndex: 0
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [list]
+        documentIndex: 0
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list]
         documentIndex: 0
       - isKind:
           of: Role


### PR DESCRIPTION
## Description

Closes #386.

The main Topograph API server ClusterRole renders the same Kubernetes RBAC rules regardless of the selected engine and provider. A chart installed with a combination that never reaches the Kubernetes API — for example `provider: test` with `engine: slurm` — is still granted `pods list`, `nodes get/list`, and `daemonsets get` cluster-wide.

This change gates the main ClusterRole rules on `engine.name` and `provider.name`, extending the gating pattern already applied to `pods/exec`, `configmaps`, and `nodes patch`.

## Gating

| Rule | Rendered when |
|---|---|
| `nodes get,list` | engine `k8s`, `slinky`, `nfd`, or provider `dra`, `infiniband-k8s` |
| `nodes patch` | engine `k8s` or `slinky` (unchanged) |
| `pods list` | engine `slinky` or provider `infiniband-k8s` |
| `daemonsets get` | provider `infiniband-k8s` |
| `configmaps create,get,update` | engine `slinky` (unchanged) |
| `pods/exec create` | provider `infiniband-k8s`, or Slinky partition discovery (unchanged) |

The ClusterRole and ClusterRoleBinding are omitted entirely when no rule applies. The namespaced NFD `Role` and `RoleBinding` are unaffected and continue to render for `engine: nfd`. There is no change to the node-observer or node-data-broker RBAC, to any values schema key, or to any Go code.

## Validation

From PR head c71a7b0 rebased on main at 6466969, helm v4.1.1 with helm-unittest 1.1.1:

- `helm lint charts/topograph`: 1/1 chart linted, 0 failed.
- `helm unittest charts/topograph`: 141/141 tests passed across 19/19 suites, 153/153 snapshots passed.

The rbac suite adds coverage for the `dra` provider (nodes without pods or daemonsets), the `infiniband-k8s` provider (pods, daemonsets, and pods/exec), the `nfd` engine (nodes without pods or node patch), the `slurm` engine with a Kubernetes provider (ClusterRole still rendered), and `test` + `slurm` (0 documents rendered).

Snapshot deltas are confined to the ClusterRole document in seven umbrella renders: `pods list` and `daemonsets get` drop from the four `k8s`-engine renders, and `daemonsets get` drops from the three `slinky` renders. The `values.k8s.ib-example.yaml` snapshot is unchanged, which is the control — `infiniband-k8s` retains both rules.

## Limits

The gates read Helm values, while `/v1/generate` accepts `provider.name` and `engine.name` in the request payload and falls back to the configured values only when the request omits them (`pkg/server/http_server.go:181`). A deployment installed for one combination and sent a request naming a Kubernetes-backed engine or provider will receive `Forbidden` from the API server. This mismatch predates the change — main already gates `pods/exec`, `configmaps`, and `nodes patch` the same way — but the change widens the surface it applies to. Constraining request-time selection to the configured values, or documenting the deployment contract, is a separate decision for maintainers.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (git commit -s).