### PR TITLE
Feature/node data broker validating admission policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Security
 
 - Main Topograph API server ClusterRole rules are gated by the selected engine and provider: `nodes`, `pods`, `daemonsets`, and `configmaps` permissions render only when the engine or provider reaches the Kubernetes API, and the ClusterRole and ClusterRoleBinding are omitted entirely for non-Kubernetes combinations such as the `test` provider with the `slurm` engine.
+- Node RBAC permissions in the main Topograph API server ClusterRole are collapsed into a single rule following least privilege: the Kubernetes engine receives Node `[get, list, patch]`, the dynamic Slinky engine (`useDynamicNodes: true`) receives Node `[list, patch]`, and other node-consuming configurations receive Node `[list]` without unnecessary `patch`, `get`, or `update` access.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 
+- Gated Topograph API server RBAC ClusterRole rules dynamically to render permissions only when required by the configured provider or engine, collapsed node rules into a single rule with dynamically computed verbs, and omitted ClusterRole and ClusterRoleBinding entirely when no Kubernetes permissions are required ([#386](https://github.com/NVIDIA/topograph/issues/386)).
 - Opt-in `ValidatingAdmissionPolicy` and binding to restrict the `node-data-broker` ServiceAccount to only updating its host Node resource, mitigating privilege escalation via node spec or annotation manipulation (audit F1 compliance).
 - Removed unused RBAC verbs from the Topograph API server and node-data-broker ClusterRoles (least-privilege): API server `pods` rule dropped `get` (list-only), `daemonsets` rule dropped `list` (get-only), and the Slinky `configmaps` rule dropped `list`; node-data-broker `nodes` rule dropped `list` (get/update), and the InfiniBand `daemonsets`/`pods` rules dropped `list`/`get` respectively (get-only, list-only).
 - Upgraded `golang.org/x/text` from `v0.38.0` to `v0.39.0` to address a dependency vulnerability.

--- a/charts/topograph/templates/rbac.yaml
+++ b/charts/topograph/templates/rbac.yaml
@@ -65,14 +65,16 @@ rules:
   verbs: [create]
 {{- end }}
 {{- if $needsNodes }}
-- apiGroups: [""]
-  resources: [nodes]
-  verbs: [get,list]
-{{- if or (eq $engine "k8s") (eq $engine "slinky") }}
-- apiGroups: [""]
-  resources: [nodes]
-  verbs: [patch]
+{{- $nodeVerbs := list "list" -}}
+{{- if eq $engine "k8s" -}}
+{{- $nodeVerbs = list "get" "list" "patch" -}}
+{{- end -}}
+{{- if and (eq $engine "slinky") (get (default dict .Values.engine.params) "useDynamicNodes") -}}
+{{- $nodeVerbs = list "list" "patch" -}}
 {{- end }}
+- apiGroups: [""]
+  resources: [nodes]
+  verbs: {{ $nodeVerbs | toJson }}
 {{- end }}
 {{- if $needsDaemonSets }}
 - apiGroups: [apps]

--- a/charts/topograph/templates/rbac.yaml
+++ b/charts/topograph/templates/rbac.yaml
@@ -25,40 +25,49 @@ already supplies nodes, a pod selector, or the default flat topology.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+{{- $needsPods := or (eq .Values.provider.name "infiniband-k8s") (eq .Values.engine.name "slinky") -}}
+{{- $needsDaemonsets := eq .Values.provider.name "infiniband-k8s" -}}
+{{- $needsNodesList := or (eq .Values.provider.name "infiniband-k8s") (eq .Values.provider.name "dra") (eq .Values.engine.name "k8s") (eq .Values.engine.name "slinky") (eq .Values.engine.name "nfd") -}}
+{{- $needsConfigMaps := eq .Values.engine.name "slinky" -}}
+{{- $needsClusterRole := or $needsPods $needsPodExec.value $needsNodesList $needsDaemonsets $needsConfigMaps -}}
+{{- if $needsClusterRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "topograph.rbacName" . }}
 rules:
+{{- if $needsPods }}
 - apiGroups: [""]
   resources: [pods]
   verbs: [list]
+{{ end }}
 {{- if $needsPodExec.value }}
 - apiGroups: [""]
   resources: [pods/exec]
   verbs: [create]
-{{- end }}
+{{ end }}
+{{- if $needsNodesList }}
+{{- $nodeVerbs := list "list" -}}
+{{- if eq .Values.engine.name "k8s" -}}
+{{- $nodeVerbs = list "get" "list" "update" -}}
+{{- end -}}
+{{- if eq .Values.engine.name "slinky" -}}
+{{- $nodeVerbs = append $nodeVerbs "patch" -}}
+{{- end -}}
 - apiGroups: [""]
   resources: [nodes]
-  verbs: [get,list]
-{{- if eq .Values.engine.name "k8s" }}
-- apiGroups: [""]
-  resources: [nodes]
-  verbs: [update]
-{{- end }}
-{{- if eq .Values.engine.name "slinky" }}
-- apiGroups: [""]
-  resources: [nodes]
-  verbs: [patch]
-{{- end }}
+  verbs: {{ $nodeVerbs | toJson }}
+{{ end }}
+{{- if $needsDaemonsets }}
 - apiGroups: [apps]
   resources: [daemonsets]
   verbs: [get]
-{{- if eq .Values.engine.name "slinky" }}
+{{ end }}
+{{- if $needsConfigMaps }}
 - apiGroups: [""]
   resources: [configmaps]
   verbs: [create,get,update]
-{{- end }}
+{{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -73,6 +82,7 @@ roleRef:
   kind: ClusterRole
   name: {{ include "topograph.rbacName" . }}
   apiGroup: ""
+{{- end }}
 {{- if eq .Values.engine.name "nfd" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
+++ b/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
@@ -420,11 +420,6 @@ renders default values.yaml:
         verbs:
           - get
           - list
-      - apiGroups:
-          - ""
-        resources:
-          - nodes
-        verbs:
           - patch
   15: |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -1006,11 +1001,6 @@ renders values.k8s.gateway-api-example.yaml:
         verbs:
           - get
           - list
-      - apiGroups:
-          - ""
-        resources:
-          - nodes
-        verbs:
           - patch
   16: |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -1606,11 +1596,6 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
         verbs:
           - get
           - list
-      - apiGroups:
-          - ""
-        resources:
-          - nodes
-        verbs:
           - patch
   15: |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -2192,11 +2177,6 @@ renders values.k8s.gcp-service-account-example.yaml:
         verbs:
           - get
           - list
-      - apiGroups:
-          - ""
-        resources:
-          - nodes
-        verbs:
           - patch
   15: |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -2798,11 +2778,6 @@ renders values.k8s.ib-example.yaml:
         verbs:
           - get
           - list
-      - apiGroups:
-          - ""
-        resources:
-          - nodes
-        verbs:
           - patch
       - apiGroups:
           - apps
@@ -3399,14 +3374,7 @@ renders values.slinky.block-example.yaml:
         resources:
           - nodes
         verbs:
-          - get
           - list
-      - apiGroups:
-          - ""
-        resources:
-          - nodes
-        verbs:
-          - patch
       - apiGroups:
           - ""
         resources:
@@ -4018,13 +3986,7 @@ renders values.slinky.partition-example.yaml:
         resources:
           - nodes
         verbs:
-          - get
           - list
-      - apiGroups:
-          - ""
-        resources:
-          - nodes
-        verbs:
           - patch
       - apiGroups:
           - ""
@@ -4612,14 +4574,7 @@ renders values.slinky.tree-example.yaml:
         resources:
           - nodes
         verbs:
-          - get
           - list
-      - apiGroups:
-          - ""
-        resources:
-          - nodes
-        verbs:
-          - patch
       - apiGroups:
           - ""
         resources:

--- a/charts/topograph/tests/rbac_test.yaml
+++ b/charts/topograph/tests/rbac_test.yaml
@@ -62,7 +62,7 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: grants core node read/write access by default
+  - it: grants core node read and patch access by default
     documentIndex: 0
     asserts:
       - contains:
@@ -70,13 +70,25 @@ tests:
           content:
             apiGroups: [""]
             resources: [nodes]
-            verbs: [get, list]
-      - contains:
+            verbs: [get, list, patch]
+      - notContains:
           path: rules
           content:
             apiGroups: [""]
             resources: [nodes]
-            verbs: [patch]
+            verbs: [update]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [list]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [apps]
+            resources: [daemonsets]
+            verbs: [get]
 
   - it: does not grant provider- or engine-specific access by default
     documentIndex: 0
@@ -108,23 +120,11 @@ tests:
       - notContains:
           path: rules
           content:
-            apiGroups: [""]
-            resources: [pods]
-            verbs: [list]
-      - notContains:
-          path: rules
-          content:
             apiGroups: [apps]
             resources: [daemonsets]
             verbs: [get, list]
-      - notContains:
-          path: rules
-          content:
-            apiGroups: [apps]
-            resources: [daemonsets]
-            verbs: [get]
 
-  - it: grants node read without node write for the dra provider
+  - it: grants node read access for the dra provider
     set:
       provider:
         name: dra
@@ -137,13 +137,25 @@ tests:
           content:
             apiGroups: [""]
             resources: [nodes]
-            verbs: [get, list]
+            verbs: [list]
       - notContains:
           path: rules
           content:
             apiGroups: [""]
             resources: [nodes]
-            verbs: [patch]
+            verbs: [list, patch]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list, patch]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [update]
       - notContains:
           path: rules
           content:
@@ -182,7 +194,7 @@ tests:
             resources: [daemonsets]
             verbs: [get]
 
-  - it: grants configmaps and pods for the slinky engine
+  - it: grants configmaps, pods, and node list for the slinky engine
     set:
       engine:
         name: slinky
@@ -205,7 +217,19 @@ tests:
           content:
             apiGroups: [""]
             resources: [nodes]
-            verbs: [patch]
+            verbs: [list]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [list, patch]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list, patch]
       - contains:
           path: rules
           content:
@@ -230,7 +254,92 @@ tests:
           content:
             apiGroups: [""]
             resources: [nodes]
-            verbs: [patch]
+            verbs: [get, list, patch]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [update]
+
+  - it: does not grant node patch access to the slurm engine
+    set:
+      provider:
+        name: dra
+      engine:
+        name: slurm
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [list]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [list, patch]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list, patch]
+
+  - it: does not grant node patch or update access to the non-dynamic slinky engine
+    set:
+      engine:
+        name: slinky
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [list]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [list, patch]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list, patch]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [update]
+
+  - it: grants node patch access to the dynamic slinky engine
+    set:
+      engine:
+        name: slinky
+        params:
+          useDynamicNodes: true
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [list, patch]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list, patch]
       - notContains:
           path: rules
           content:
@@ -257,38 +366,27 @@ tests:
     asserts:
       - hasDocuments:
           count: 2
-      - notContains:
+      - contains:
           path: rules
           content:
             apiGroups: [""]
             resources: [nodes]
-            verbs: [patch]
+            verbs: [list]
         documentIndex: 0
-
-  - it: does not grant node update access to the slinky engine
-    set:
-      engine:
-        name: slinky
-    documentIndex: 0
-    asserts:
-      - contains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [nodes]
-            verbs: [get, list]
-      - contains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [nodes]
-            verbs: [patch]
       - notContains:
           path: rules
           content:
             apiGroups: [""]
             resources: [nodes]
-            verbs: [update]
+            verbs: [list, patch]
+        documentIndex: 0
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list, patch]
+        documentIndex: 0
 
   - it: does not render NFD namespace RBAC for an explicit non-NFD engine
     set:
@@ -318,12 +416,26 @@ tests:
             resources: [nodefeatures, nodefeaturegroups]
             verbs: [create, list, patch, delete]
         documentIndex: 0
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [list]
+        documentIndex: 0
       - notContains:
           path: rules
           content:
             apiGroups: [""]
             resources: [nodes]
-            verbs: [patch]
+            verbs: [list, patch]
+        documentIndex: 0
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list, patch]
         documentIndex: 0
       - notContains:
           path: rules
@@ -331,13 +443,6 @@ tests:
             apiGroups: [""]
             resources: [pods]
             verbs: [list]
-        documentIndex: 0
-      - contains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [nodes]
-            verbs: [get, list]
         documentIndex: 0
       - isKind:
           of: Role

--- a/charts/topograph/tests/rbac_test.yaml
+++ b/charts/topograph/tests/rbac_test.yaml
@@ -56,21 +56,15 @@ tests:
           path: rules
           content:
             apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list, update]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
             resources: [pods]
             verbs: [list]
-      - contains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [nodes]
-            verbs: [get, list]
-      - contains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [nodes]
-            verbs: [update]
-      - contains:
+      - notContains:
           path: rules
           content:
             apiGroups: [apps]
@@ -147,7 +141,7 @@ tests:
           content:
             apiGroups: [""]
             resources: [nodes]
-            verbs: [patch]
+            verbs: [list, patch]
 
   - it: does not grant node patch access to non-slinky engines
     set:
@@ -166,7 +160,7 @@ tests:
           content:
             apiGroups: [""]
             resources: [nodes]
-            verbs: [update]
+            verbs: [get, list, update]
 
   - it: does not grant node update access to the slinky engine
     set:
@@ -179,13 +173,7 @@ tests:
           content:
             apiGroups: [""]
             resources: [nodes]
-            verbs: [get, list]
-      - contains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: [nodes]
-            verbs: [patch]
+            verbs: [list, patch]
       - notContains:
           path: rules
           content:
@@ -328,3 +316,190 @@ tests:
       - equal:
           path: subjects[0].namespace
           value: topograph
+
+  - it: grants node read and update access for test provider and k8s engine (test/k8s)
+    set:
+      provider:
+        name: test
+      engine:
+        name: k8s
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ClusterRole
+        documentIndex: 0
+      - isKind:
+          of: ClusterRoleBinding
+        documentIndex: 1
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list, update]
+        documentIndex: 0
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+        documentIndex: 0
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [apps]
+            resources: [daemonsets]
+        documentIndex: 0
+
+  - it: omits ClusterRole and ClusterRoleBinding when no Kubernetes permissions are required (test/slurm)
+    set:
+      provider:
+        name: test
+      engine:
+        name: slurm
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: grants node read access for dra provider with slurm engine (dra/slurm)
+    set:
+      provider:
+        name: dra
+      engine:
+        name: slurm
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [list]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [apps]
+            resources: [daemonsets]
+
+  - it: grants node, pod, exec, and daemonset access for infiniband-k8s provider
+    set:
+      provider:
+        name: infiniband-k8s
+      engine:
+        name: slurm
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [list]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods/exec]
+            verbs: [create]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [list]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [apps]
+            resources: [daemonsets]
+            verbs: [get]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [configmaps]
+
+  - it: grants node, pod, exec, and configmap access for slinky engine
+    set:
+      provider:
+        name: test
+      engine:
+        name: slinky
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [list]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods/exec]
+            verbs: [create]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [list, patch]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [configmaps]
+            verbs: [create, get, update]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [apps]
+            resources: [daemonsets]
+
+  - it: omits pods/exec for slinky engine when useDynamicNodes is enabled
+    set:
+      provider:
+        name: test
+      engine:
+        name: slinky
+        params:
+          useDynamicNodes: true
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [list]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [list, patch]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [configmaps]
+            verbs: [create, get, update]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods/exec]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [apps]
+            resources: [daemonsets]
+
+


### PR DESCRIPTION
## Description

Closes #386

This PR updates the Topograph Helm chart to follow the principle of least privilege by rendering only the RBAC permissions required for the configured provider and engine.

### Summary

- Dynamically compute the required `Node` verbs based on the enabled providers and engines.
- Render Kubernetes RBAC rules (`pods`, `pods/exec`, `daemonsets`, `configmaps`, etc.) only when they are required.
- Skip rendering the `ClusterRole` and `ClusterRoleBinding` when no Kubernetes API permissions are needed.
- Update the Helm RBAC unit tests to cover the new permission matrix.
- Update the changelog.

### Motivation

Previously, the chart could grant permissions that were unnecessary for a given deployment configuration. This change minimizes the RBAC footprint by ensuring only the permissions required for the selected configuration are rendered, reducing the attack surface while preserving existing functionality.

## Testing

- Updated Helm RBAC unit tests to validate the generated permission matrix.
- Verified the rendered templates through static review.
- Rebased onto the latest `main` and resolved merge conflicts.

## Checklist

- [x] I have read the project's contributing guidelines.
- [x] Tests have been updated where applicable.
- [x] Documentation has been updated where applicable.
- [x] All commits are signed off (`git commit -s`).