### PR TITLE
feat(provider/lambdai): add Kubernetes workload identity auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Helm chart metadata: `home`, `icon`, `maintainers`, `keywords`, and Artifact Hub annotations ([#377](https://github.com/NVIDIA/topograph/pull/377)).
 - Helm `env`, `initContainers`, and `lifecycle` overrides across the API server, node-observer, and node-data-broker containers.
 - Lambda provider Kubernetes node-data-broker support: Topograph instance and region annotations are derived from Lambda node `.spec.providerID` and `topology.kubernetes.io/region`, enabling automatic node discovery with the Kubernetes engine ([#375](https://github.com/NVIDIA/topograph/pull/375)).
+- `lambdai` provider supports Kubernetes workload identity via `lambda-pod-identity-webhook` (OIDC token exchange) for short-lived Lambda API credentials, removing the need for a long-lived API-token Secret.
 - `kwok-nodes` utility and helper script for rendering model-derived KWOK node manifests, creating local kind clusters, and installing KWOK.
 
 ### Changed

--- a/charts/topograph/values.k8s.lambdai-workload-identity-example.yaml
+++ b/charts/topograph/values.k8s.lambdai-workload-identity-example.yaml
@@ -1,0 +1,28 @@
+provider:
+  name: lambdai
+  params:
+    url: https://cloud.lambda.ai
+    # workspaceId is an identifier, not a secret; with workload identity no
+    # credentialsSecret is needed.
+    workspaceId: "<WORKSPACE_ID>"
+
+engine:
+  name: k8s
+
+# lambda-pod-identity-webhook injects the projected ServiceAccount token and the
+# LAMBDA_ROLE_LRN / LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE env vars into the
+# API-server pod because its ServiceAccount carries this annotation. No token
+# Secret, no audience, and no chart-managed volume are required.
+serviceAccount:
+  annotations:
+    lambda.ai/role-lrn: "lrn:iam:identity:<id>"
+
+nodeObserver:
+  topograph:
+    trigger:
+      nodeSelector:
+        kubernetes.io/os: linux
+
+nodeDataBroker:
+  tolerations:
+    - operator: Exists

--- a/docs/providers/lambdai.md
+++ b/docs/providers/lambdai.md
@@ -21,8 +21,10 @@ With the **Slurm engine**, `lambdai` does **not** auto-discover nodes: the topol
 
 | Field | Required | Description |
 |---|---|---|
-| `workspaceId` | Yes | Lambda workspace ID; sent as the `workspace_id` query parameter |
-| `token` | Yes | Bearer token used for topology API requests |
+| `workspaceId` | Yes\* | Lambda workspace ID; sent as the `workspace_id` query parameter |
+| `token` | Yes\* | Bearer token used for topology API requests |
+
+\* Required for static-token authentication. With [workload identity](#authentication-via-workload-identity) no credentials are needed — the API token is minted at runtime and `workspaceId` is supplied as a provider parameter instead. A `token` supplied here always takes precedence over a workload identity.
 
 Store credentials in a YAML file:
 
@@ -39,11 +41,99 @@ credentialsPath: /etc/topograph/lambdai-credentials.yaml
 
 Credentials can also be supplied directly in the topology request payload under `provider.creds`.
 
+## Authentication via Workload Identity
+
+Instead of storing a long-lived API token in a Kubernetes Secret, Topograph can authenticate with **Kubernetes workload identity**. On a Lambda Kubernetes Service (LKS) cluster, Lambda's `lambda-pod-identity-webhook` injects a projected ServiceAccount token into the API-server pod; Topograph exchanges that token at Lambda's OIDC endpoint (`POST /api/v1/oidc/token`) for a short-lived Lambda API key, which it uses for topology requests and refreshes automatically before expiry. No API token ever lives in the cluster.
+
+The cluster's OIDC provider (issuer + JWKS) is **pre-registered by LKS** at provisioning, so there is no `audience` to manage and no provider to register from scratch. You only create an identity, grant it access, and trust the ServiceAccount subject.
+
+### Prerequisites
+
+- An **LKS cluster** — its OIDC issuer and public JWKS are registered with Lambda automatically at provisioning.
+- **`lambda-pod-identity-webhook`** installed in the cluster (LKS ships it). The webhook watches for pods whose ServiceAccount is annotated `lambda.ai/role-lrn` and mutates them to inject the projected token and identity env vars.
+- **Workload identity enabled** for your Lambda account.
+- A Lambda **admin API key** for the one-time operator setup below.
+
+### 1. Create the identity and attach a trust (operator, out of band)
+
+Using an admin key, create a service identity, add it to the workspace whose topology you will read, and assign it the `workload-identity` role (workspace-scoped `COMPUTE_INSTANCE_READ`). Note the returned **identity LRN** (`lrn:iam:identity:<id>`).
+
+Then trust Topograph's ServiceAccount to assume that identity. LKS already registered the cluster's OIDC provider, but it does not trust any of your ServiceAccounts — that part is yours. Because there is no lookup-by-issuer API, re-posting the issuer and JWKS acts as an idempotent upsert that returns the provider LKS already registered:
+
+```bash
+# The cluster's issuer and public JWKS, read from the workload cluster.
+ISS=$(kubectl get --raw /.well-known/openid-configuration | jq -r .issuer)
+kubectl get --raw /openid/v1/jwks > /tmp/jwks.json
+
+# Idempotent upsert -> the existing provider_id for this issuer.
+PID=$(curl -s -X POST -H "Authorization: Bearer $LAMBDA_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" "$URL/api/v1/oidc-providers" \
+  -d "$(jq -n --arg iss "$ISS" --slurpfile jwks /tmp/jwks.json \
+        '{issuer_url:$iss, jwks:$jwks[0]}')" | jq -r .data.provider_id)
+
+# Add the trust. PATCH is additive, so other trusts are left alone.
+curl -s -X PATCH -H "Authorization: Bearer $LAMBDA_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$URL/api/v1/identities/<identity-id>/oidc-trusts" \
+  -d "$(jq -n --arg pid "$PID" \
+        --arg sub "system:serviceaccount:<namespace>:<topograph-serviceaccount>" \
+        '{trusts:[{provider_id:$pid, subject:$sub}]}')"
+```
+
+- `subject` is the projected token's `sub` claim, `system:serviceaccount:<namespace>:<serviceAccountName>`. Use `"*"` to trust any subject under the issuer (least restrictive).
+- The provider upsert reports the `audience` it expects (`lambda-workload-identity`); the webhook stamps that same audience onto the projected token, so there is nothing to configure.
+
+### 2. Configure Topograph
+
+Annotate Topograph's ServiceAccount with the identity LRN and set the provider params — no Secret and no audience:
+
+```yaml
+provider:
+  name: lambdai
+  params:
+    url: https://cloud.lambda.ai
+    workspaceId: "<WORKSPACE_ID>"
+
+serviceAccount:
+  annotations:
+    lambda.ai/role-lrn: "lrn:iam:identity:<id>"
+```
+
+`workspaceId` is an identifier, not a secret, so it lives in params and no `config.credentialsSecret` is required. The webhook keys off the `lambda.ai/role-lrn` annotation on the pod's ServiceAccount — there is no `workloadIdentity` parameter and no chart-managed volume.
+
+### 3. Install with Helm (no credentials Secret)
+
+```bash
+helm install topograph oci://ghcr.io/nvidia/topograph/topograph \
+  --version <chart-version> -n topograph --create-namespace \
+  -f values.k8s.lambdai-workload-identity-example.yaml
+```
+
+See [`values.k8s.lambdai-workload-identity-example.yaml`](../../charts/topograph/values.k8s.lambdai-workload-identity-example.yaml) for a complete example. Unlike the static-token flow, **no `config.credentialsSecret` is set**.
+
+### How it works
+
+Because the pod's ServiceAccount carries the `lambda.ai/role-lrn` annotation, `lambda-pod-identity-webhook` mutates the pod to inject:
+
+- a projected ServiceAccount token at `/var/run/secrets/lambda.ai/serviceaccount/token`, and
+- the env vars `LAMBDA_ROLE_LRN` (the identity LRN) and `LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE` (the token path).
+
+Topograph reads `LAMBDA_ROLE_LRN` to switch into workload-identity mode, reads the projected token from `LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE`, and exchanges it at `POST /api/v1/oidc/token` for a Lambda API key. The key is cached process-wide and refreshed shortly (≈5 minutes, jittered) before expiry so a fleet of pods does not refresh in lockstep. A transient exchange failure while the cached key is still valid is tolerated — Topograph keeps serving the current key until it actually expires. If the Lambda API rejects a cached key mid-life, Topograph mints a new one and retries the request once.
+
+The pod identity is a fallback, not an override: a request (or `credentialsPath`) that supplies a `token` credential authenticates with **that** token even when the pod carries a workload identity, so a caller's credentials are never silently replaced by the pod's principal. Topograph logs which one it used. Supplying a `token` that is empty or whitespace is treated as a malformed credential and rejected with `400` — not as a request to fall back to the pod identity. To use workload identity, omit the `token` credential entirely.
+
+### Caveats
+
+- **Stable subject.** The trust pins the token's `sub` claim, `system:serviceaccount:<namespace>:<serviceAccountName>`. The chart's generated ServiceAccount name derives from the release name and can change; set a fixed `serviceAccount.name` and trust that exact subject (or use `"*"`) so the trust keeps matching.
+- **JWKS rotation is handled by LKS.** LKS keeps the cluster's registered issuer and JWKS current, so key rotation does not require operator action.
+- **Opaque failures.** The token-exchange endpoint returns an identical `401` for every failure (unknown issuer, untrusted subject, missing role). Topograph logs only the HTTP status and the identity LRN; check the pod logs for `workload-identity token exchange failed (status ...)` and verify the trust, subject, and role.
+
 ## Parameters
 
 | Field | Required | Description |
 |---|---|---|
 | `url` | Yes | Base URL for the Lambda topology API, for example `https://cloud.example.com` |
+| `workspaceId` | No | Lambda workspace ID. Normally supplied as a credential; in [workload-identity mode](#authentication-via-workload-identity) it may be given here instead (it is an identifier, not a secret), so that no Secret is required. |
 | `trimTiers` | No | Number of highest topology tiers to trim from output. Defaults to `0` |
 
 The region is **not** a parameter — it is taken from each entry in the request's `nodes` list and forwarded to the API as the `region` query parameter (the API requires it). The top-level Topograph `pageSize` setting controls the page size for paginated topology requests.

--- a/pkg/providers/lambdai/provider.go
+++ b/pkg/providers/lambdai/provider.go
@@ -10,9 +10,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
+	"strings"
 
 	"github.com/mitchellh/mapstructure"
+	"k8s.io/klog/v2"
 
 	"github.com/NVIDIA/topograph/internal/httperr"
 	"github.com/NVIDIA/topograph/internal/httpreq"
@@ -52,13 +55,14 @@ type credentialsConfig struct {
 }
 
 type paramsConfig struct {
-	BaseURL string `mapstructure:"url"`
+	BaseURL     string `mapstructure:"url"`
+	WorkspaceID string `mapstructure:"workspaceId"` // optional alternative to the workspaceId credential
 }
 
 // lambdaiClient is a Topology API client.
 type lambdaiClient struct {
 	baseURL     string
-	bearerToken string
+	token       tokenProvider
 	workspaceID string
 	pageSize    int
 }
@@ -110,8 +114,34 @@ func (c *lambdaiClient) PageSize() int {
 	return c.pageSize
 }
 
+// invalidator is implemented by token sources whose cached key can be dropped
+// (the workload-identity credential); staticToken does not.
+type invalidator interface{ InvalidateIfCurrent(token string) }
+
+// InstanceList lists instance topology. A 401 can mean the minted
+// workload-identity key was rejected mid-life, so drop that specific key and
+// retry once with a freshly minted one. Static tokens cannot be refreshed, so
+// their 401 surfaces unchanged.
 func (c *lambdaiClient) InstanceList(ctx context.Context, req *InstanceListRequest) (*InstanceListResponse, error) {
-	headers := map[string]string{"Authorization": "Bearer " + c.bearerToken}
+	bearer, resp, err := c.instanceListOnce(ctx, req)
+	if he, ok := err.(*httperr.Error); ok && he.Code() == http.StatusUnauthorized {
+		if inv, ok := c.token.(invalidator); ok {
+			// Pass the rejected key so a replacement minted concurrently survives.
+			inv.InvalidateIfCurrent(bearer)
+			_, resp, err = c.instanceListOnce(ctx, req)
+		}
+	}
+	return resp, err
+}
+
+// instanceListOnce returns the bearer token it used alongside the result, so a
+// caller handling a 401 can invalidate exactly that key and nothing newer.
+func (c *lambdaiClient) instanceListOnce(ctx context.Context, req *InstanceListRequest) (string, *InstanceListResponse, error) {
+	bearer, herr := c.token.Token(ctx)
+	if herr != nil {
+		return "", nil, herr
+	}
+	headers := map[string]string{"Authorization": "Bearer " + bearer}
 	query := map[string]string{
 		"workspace_id": c.workspaceID,
 		"region":       req.Region,
@@ -127,15 +157,15 @@ func (c *lambdaiClient) InstanceList(ctx context.Context, req *InstanceListReque
 
 	body, httpErr := httpreq.DoRequestWithRetries(f, false)
 	if httpErr != nil {
-		return nil, httpErr
+		return bearer, nil, httpErr
 	}
 
 	var apiResp apiResponse
 	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
+		return bearer, nil, httperr.NewError(http.StatusBadGateway, err.Error())
 	}
 
-	return &InstanceListResponse{
+	return bearer, &InstanceListResponse{
 		Items:         apiResp.Data,
 		NextPageToken: apiResp.PageToken,
 	}, nil
@@ -146,23 +176,82 @@ func NamedLoader() (string, providers.Loader) {
 }
 
 func Loader(ctx context.Context, config providers.Config) (providers.Provider, *httperr.Error) {
-	creds, err := decodeCredentials(config.Creds)
-	if err != nil {
-		return nil, httperr.NewError(http.StatusBadRequest, "credentials error: "+err.Error())
-	}
 	params, err := decodeParams(config.Params)
 	if err != nil {
 		return nil, httperr.NewError(http.StatusBadRequest, "parameters error: "+err.Error())
 	}
+
+	creds, err := decodeCredentials(config.Creds)
+	if err != nil {
+		return nil, httperr.NewError(http.StatusBadRequest, "credentials error: "+err.Error())
+	}
+
+	// lambda-pod-identity-webhook injects LAMBDA_ROLE_LRN into pods whose
+	// ServiceAccount carries the lambda.ai/role-lrn annotation. That identity is
+	// ambient pod infrastructure, so a token supplied with the request takes
+	// precedence over it -- the same explicit-then-ambient tiering the aws
+	// provider applies. Without that precedence a pod running under workload
+	// identity would authenticate every request as its own principal, silently
+	// ignoring the caller's token and reading the wrong workspace.
+	//
+	// Selection keys off the *presence* of the token credential, not its decoded
+	// value: mapstructure renders an absent, empty and nil token alike as "", so
+	// testing the value would let a malformed credential fall through to the pod
+	// identity instead of being rejected. Naming the key at all opts into static
+	// authentication, and a blank value is then a validation error.
+	tokenSupplied := credentialSupplied(config.Creds, authToken)
+	identityLRN := os.Getenv(envRoleLRN)
+	wiMode := !tokenSupplied && identityLRN != ""
+
+	// Announce the selected credential in every branch, as the aws provider does,
+	// so which principal a pod authenticates as is always visible in its log.
+	if wiMode {
+		klog.InfoS("Using Lambda workload identity credentials", "identityLRN", identityLRN)
+	} else {
+		if err := requireStaticCredentials(creds); err != nil {
+			return nil, httperr.NewError(http.StatusBadRequest, "credentials error: "+err.Error())
+		}
+		if identityLRN != "" {
+			klog.InfoS("Using the provided Lambda API token; ignoring the pod's ambient workload identity",
+				"identityLRN", identityLRN)
+		} else {
+			klog.Info("Using the provided Lambda API token")
+		}
+	}
+
 	trimTiers, err := providers.GetTrimTiers(config.Params)
 	if err != nil {
 		return nil, httperr.NewError(http.StatusBadRequest, "parameters error: "+err.Error())
 	}
 
+	// In workload-identity mode the workspaceId may come from params (it is an
+	// identifier, not a secret), so no Secret is required. Static mode already
+	// required it as a credential in requireStaticCredentials.
+	workspaceID := creds.WorkspaceID
+	if workspaceID == "" {
+		workspaceID = params.WorkspaceID
+	}
+	if workspaceID == "" {
+		return nil, httperr.NewError(http.StatusBadRequest, fmt.Sprintf("parameters error: missing '%s'", authWorkspaceID))
+	}
+
+	var tp tokenProvider
+	if wiMode {
+		// The webhook also injects the token path; fall back to its documented
+		// default mount point when the env var is absent.
+		tokenPath := os.Getenv(envTokenFile)
+		if tokenPath == "" {
+			tokenPath = defaultSATokenPath
+		}
+		tp = sharedCredential(params.BaseURL, identityLRN, tokenPath)
+	} else {
+		tp = staticToken(creds.Token)
+	}
+
 	clientFactory := func(pageSize *int) (Client, error) {
 		return &lambdaiClient{
-			workspaceID: creds.WorkspaceID,
-			bearerToken: creds.Token,
+			workspaceID: workspaceID,
+			token:       tp,
 			baseURL:     params.BaseURL,
 			pageSize:    getPageSize(pageSize),
 		}, nil
@@ -177,13 +266,45 @@ func decodeCredentials(creds map[string]any) (*credentialsConfig, error) {
 		return nil, err
 	}
 
-	for _, key := range []string{authWorkspaceID, authToken} {
-		if v, ok := creds[key]; !ok || v == nil {
-			return nil, fmt.Errorf("missing '%s'", key)
+	return c, nil
+}
+
+// credentialSupplied reports whether the credential map names the given key.
+//
+// The comparison is case-insensitive because that is how mapstructure matches
+// keys onto struct fields. Deciding the authentication mode with stricter
+// matching than the decoder uses would reintroduce a silent downgrade: a variant
+// spelling such as "Token" populates the decoded token, but an exact lookup would
+// report it absent and fall back to the pod identity, discarding the caller's
+// credential.
+func credentialSupplied(creds map[string]any, key string) bool {
+	for k := range creds {
+		if strings.EqualFold(k, key) {
+			return true
 		}
 	}
 
-	return c, nil
+	return false
+}
+
+// requireStaticCredentials enforces what static-token authentication needs.
+// Workload-identity mode skips it: the token is minted at runtime and the
+// workspace may be supplied as a provider parameter instead.
+//
+// A blank value is rejected like an absent one -- an empty or whitespace-only
+// token is unusable, and accepting it would send a credential-less "Bearer "
+// header instead of reporting the malformed credential.
+func requireStaticCredentials(creds *credentialsConfig) error {
+	for _, cred := range []struct{ key, val string }{
+		{authWorkspaceID, creds.WorkspaceID},
+		{authToken, creds.Token},
+	} {
+		if strings.TrimSpace(cred.val) == "" {
+			return fmt.Errorf("missing '%s'", cred.key)
+		}
+	}
+
+	return nil
 }
 
 func decodeParams(params map[string]any) (*paramsConfig, error) {

--- a/pkg/providers/lambdai/provider.go
+++ b/pkg/providers/lambdai/provider.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -181,6 +182,10 @@ func Loader(ctx context.Context, config providers.Config) (providers.Provider, *
 		return nil, httperr.NewError(http.StatusBadRequest, "parameters error: "+err.Error())
 	}
 
+	if err := requireUnambiguousCredentials(config.Creds); err != nil {
+		return nil, httperr.NewError(http.StatusBadRequest, "credentials error: "+err.Error())
+	}
+
 	creds, err := decodeCredentials(config.Creds)
 	if err != nil {
 		return nil, httperr.NewError(http.StatusBadRequest, "credentials error: "+err.Error())
@@ -267,6 +272,31 @@ func decodeCredentials(creds map[string]any) (*credentialsConfig, error) {
 	}
 
 	return c, nil
+}
+
+// requireUnambiguousCredentials rejects duplicate case-insensitive spellings of a
+// credential key.
+//
+// mapstructure matches keys case-insensitively, so "token" and "Token" both feed
+// the same field and Go's randomized map iteration picks a winner
+// nondeterministically -- the very same request could authenticate as a different
+// principal, or against a different workspace, from one run to the next. There is
+// no safe way to choose, so the ambiguity is reported instead of resolved.
+func requireUnambiguousCredentials(creds map[string]any) error {
+	for _, key := range []string{authWorkspaceID, authToken} {
+		var spellings []string
+		for k := range creds {
+			if strings.EqualFold(k, key) {
+				spellings = append(spellings, k)
+			}
+		}
+		if len(spellings) > 1 {
+			sort.Strings(spellings) // map order is random; keep the message stable
+			return fmt.Errorf("ambiguous '%s' credential: %s", key, strings.Join(spellings, ", "))
+		}
+	}
+
+	return nil
 }
 
 // credentialSupplied reports whether the credential map names the given key.

--- a/pkg/providers/lambdai/provider_test.go
+++ b/pkg/providers/lambdai/provider_test.go
@@ -6,9 +6,13 @@ package lambdai
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -20,9 +24,12 @@ import (
 func TestLoader(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
-		name   string
-		config providers.Config
-		err    string
+		name      string
+		roleLRN   string // LAMBDA_ROLE_LRN; non-empty selects workload-identity mode
+		config    providers.Config
+		err       string
+		wantWI    bool   // expect the workload-identity credential, not a static token
+		wantToken string // when static, the exact token the client must be given
 	}{
 		{
 			name: "Case 1: success",
@@ -97,10 +104,181 @@ func TestLoader(t *testing.T) {
 			},
 			err: "parameters error: missing 'url'",
 		},
+		{
+			name:    "Case 7: workload identity success (no token cred, workspaceId from params)",
+			roleLRN: "lrn:iam:identity:abc",
+			config: providers.Config{
+				Params: map[string]any{
+					"url":         "https://api.example.com",
+					"workspaceId": "workspace-123",
+				},
+			},
+			wantWI: true,
+		},
+		{
+			name:    "Case 8: workload identity missing workspaceId",
+			roleLRN: "lrn:iam:identity:abc",
+			config: providers.Config{
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+			err: "parameters error: missing 'workspaceId'",
+		},
+		{
+			name:    "Case 9: supplied token wins over the ambient workload identity",
+			roleLRN: "lrn:iam:identity:abc",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": "workspace-123",
+					"token":       "token-abc",
+				},
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+		},
+		{
+			// A workspaceId credential alone is not a token, so the ambient
+			// identity still applies rather than failing on the missing token.
+			name:    "Case 10: workspaceId cred with workload identity stays in WI mode",
+			roleLRN: "lrn:iam:identity:abc",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": "workspace-123",
+				},
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+			wantWI: true,
+		},
+		{
+			// Falling back to the static path with no token must still report the
+			// original credential error rather than silently using the pod identity.
+			name: "Case 11: no token and no workload identity still errors",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": "workspace-123",
+				},
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+			err: "credentials error: missing 'token'",
+		},
+		{
+			// Security: an explicitly supplied but malformed token must be
+			// rejected, never silently downgraded to the pod identity.
+			name:    "Case 12: empty token with workload identity is rejected",
+			roleLRN: "lrn:iam:identity:abc",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": "workspace-123",
+					"token":       "",
+				},
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+			err: "credentials error: missing 'token'",
+		},
+		{
+			name:    "Case 13: nil token with workload identity is rejected",
+			roleLRN: "lrn:iam:identity:abc",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": "workspace-123",
+					"token":       nil,
+				},
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+			err: "credentials error: missing 'token'",
+		},
+		{
+			name:    "Case 14: whitespace-only token with workload identity is rejected",
+			roleLRN: "lrn:iam:identity:abc",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": "workspace-123",
+					"token":       "   ",
+				},
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+			err: "credentials error: missing 'token'",
+		},
+		{
+			// Without workload identity an empty token previously passed
+			// validation and produced a credential-less "Bearer " header.
+			name: "Case 15: empty token without workload identity is rejected",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": "workspace-123",
+					"token":       "",
+				},
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+			err: "credentials error: missing 'token'",
+		},
+		{
+			name:    "Case 16: empty workspaceId credential is rejected",
+			roleLRN: "",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": "",
+					"token":       "token-abc",
+				},
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+			err: "credentials error: missing 'workspaceId'",
+		},
+		{
+			// Security: mapstructure matches credential keys case-insensitively, so
+			// mode selection must too. A case variant that populates the token must
+			// not be treated as absent and downgraded to the pod identity.
+			name:    "Case 17: case-variant token with workload identity is still used",
+			roleLRN: "lrn:iam:identity:abc",
+			config: providers.Config{
+				Creds: map[string]any{
+					"WorkspaceId": "workspace-123",
+					"Token":       "token-abc",
+				},
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+			wantToken: "token-abc",
+		},
+		{
+			name:    "Case 18: blank case-variant token with workload identity is rejected",
+			roleLRN: "lrn:iam:identity:abc",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": "workspace-123",
+					"TOKEN":       "  ",
+				},
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+			err: "credentials error: missing 'token'",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Mode is selected by env, not params: static cases pin it empty so
+			// ambient env can't flip them into workload-identity mode.
+			t.Setenv(envRoleLRN, tt.roleLRN)
+			resetCredentialCache()
 			provider, err := Loader(ctx, tt.config)
 
 			if len(tt.err) != 0 {
@@ -108,12 +286,40 @@ func TestLoader(t *testing.T) {
 				require.NotNil(t, err)
 				require.Equal(t, http.StatusBadRequest, err.Code())
 				require.Equal(t, tt.err, err.Error())
+				return
+			}
+
+			require.Nil(t, err)
+			require.NotNil(t, provider)
+
+			// Assert which credential Loader actually wired in, not merely that
+			// it built something: the static and workload-identity paths differ
+			// only in the token source.
+			tp := tokenProviderOf(t, provider)
+			if tt.wantWI {
+				require.IsType(t, &workloadIdentityCredential{}, tp, "expected the workload-identity credential")
 			} else {
-				require.Nil(t, err)
-				require.NotNil(t, provider)
+				require.IsType(t, staticToken(""), tp, "expected a static token")
+				if tt.wantToken != "" {
+					require.Equal(t, staticToken(tt.wantToken), tp,
+						"the caller's token must be the one handed to the client")
+				}
 			}
 		})
 	}
+}
+
+// tokenProviderOf digs out the token source Loader wired into the client it
+// builds, so tests can assert the selected authentication mode directly.
+func tokenProviderOf(t *testing.T, p providers.Provider) tokenProvider {
+	t.Helper()
+	prv, ok := p.(*Provider)
+	require.True(t, ok, "expected *Provider, got %T", p)
+	client, err := prv.clientFactory(nil)
+	require.NoError(t, err)
+	lc, ok := client.(*lambdaiClient)
+	require.True(t, ok, "expected *lambdaiClient, got %T", client)
+	return lc.token
 }
 
 // TestGenerateTopologyConfig drives the real client against a mock of the Lambda
@@ -122,6 +328,7 @@ func TestLoader(t *testing.T) {
 // page_token pagination, and the networkPath -> leaf/spine/core mapping.
 func TestGenerateTopologyConfig(t *testing.T) {
 	ctx := context.Background()
+	t.Setenv(envRoleLRN, "") // static-token mode: no workload identity
 
 	const page1 = `{"data":[
 		{"id":"i-1","networkPath":[{"id":"leaf1"},{"id":"spine1"},{"id":"core1"}],"nvlink":null},
@@ -182,4 +389,300 @@ SwitchName=spine1 Switches=leaf[1-2]
 SwitchName=leaf1 Nodes=node[1-2]
 SwitchName=leaf2 Nodes=node3
 `, string(out))
+}
+
+// TestGenerateTopologyConfigWorkloadIdentity drives the workload-identity path
+// end to end against a single mock server that answers both the OIDC
+// token-exchange and the topology endpoint. The webhook model is simulated by
+// setting the LAMBDA_ROLE_LRN and LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE env vars;
+// the test asserts that the provider reads the projected ServiceAccount token,
+// exchanges it once, and uses the minted key as the Bearer credential on the
+// topology request. No token or workspaceId credential is supplied.
+func TestGenerateTopologyConfigWorkloadIdentity(t *testing.T) {
+	ctx := context.Background()
+	resetCredentialCache()
+
+	saTokenPath := writeToken(t, "sa-jwt-value\n")
+	t.Setenv(envRoleLRN, "lrn:iam:identity:abc")
+	t.Setenv(envTokenFile, saTokenPath)
+
+	const topoPage = `{"data":[
+		{"id":"i-1","networkPath":[{"id":"leaf1"},{"id":"spine1"}],"nvlink":null}
+	],"page_token":null}`
+
+	var exchangeHits, topoHits int
+	var topoAuths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case oidcTokenPath:
+			exchangeHits++
+			require.Equal(t, http.MethodPost, r.Method)
+			var req exchangeRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			require.Equal(t, "sa-jwt-value", req.Token)
+			require.Equal(t, "lrn:iam:identity:abc", req.IdentityLRN)
+			_, _ = w.Write([]byte(`{"data":{"access_token":"minted-key","expires_in":3600}}`))
+		case apiPath:
+			topoHits++
+			topoAuths = append(topoAuths, r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(topoPage))
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	provider, httpErr := Loader(ctx, providers.Config{
+		Params: map[string]any{
+			apiBaseURL:      server.URL,
+			authWorkspaceID: "ws-1",
+		},
+	})
+	require.Nil(t, httpErr)
+
+	graph, httpErr := provider.GenerateTopologyConfig(ctx, nil, []topology.ComputeInstances{
+		{
+			Region:    "stg-sjc01-cl03",
+			Instances: map[string]string{"i-1": "node1"},
+		},
+	})
+	require.Nil(t, httpErr)
+	require.NotNil(t, graph)
+
+	require.Equal(t, 1, exchangeHits)
+	require.Equal(t, 1, topoHits)
+	require.Equal(t, []string{"Bearer minted-key"}, topoAuths)
+}
+
+// TestInstanceListRetriesOnUnauthorized covers the workload-identity 401 retry:
+// a minted key rejected mid-life is invalidated and re-exchanged, and the
+// topology request is replayed once with the fresh key. This is the production
+// path that reaches workloadIdentityCredential.InvalidateIfCurrent.
+func TestInstanceListRetriesOnUnauthorized(t *testing.T) {
+	ctx := context.Background()
+	resetCredentialCache()
+
+	saTokenPath := writeToken(t, "sa-jwt-value")
+	t.Setenv(envRoleLRN, "lrn:iam:identity:abc")
+	t.Setenv(envTokenFile, saTokenPath)
+
+	const topoPage = `{"data":[
+		{"id":"i-1","networkPath":[{"id":"leaf1"},{"id":"spine1"}],"nvlink":null}
+	],"page_token":null}`
+
+	var exchangeHits, topoHits int
+	var topoAuths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case oidcTokenPath:
+			exchangeHits++
+			_, _ = fmt.Fprintf(w, `{"data":{"access_token":"minted-%d","expires_in":3600}}`, exchangeHits)
+		case apiPath:
+			topoHits++
+			topoAuths = append(topoAuths, r.Header.Get("Authorization"))
+			// The first minted key is rejected; the retry with a fresh key wins.
+			if topoHits == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+				return
+			}
+			_, _ = w.Write([]byte(topoPage))
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	provider, httpErr := Loader(ctx, providers.Config{
+		Params: map[string]any{
+			apiBaseURL:      server.URL,
+			authWorkspaceID: "ws-1",
+		},
+	})
+	require.Nil(t, httpErr)
+
+	graph, httpErr := provider.GenerateTopologyConfig(ctx, nil, []topology.ComputeInstances{
+		{
+			Region:    "stg-sjc01-cl03",
+			Instances: map[string]string{"i-1": "node1"},
+		},
+	})
+	require.Nil(t, httpErr)
+	require.NotNil(t, graph)
+
+	require.Equal(t, 2, exchangeHits, "the rejected key should be invalidated and re-exchanged")
+	require.Equal(t, 2, topoHits, "the topology request should be replayed once")
+	require.Equal(t, []string{"Bearer minted-1", "Bearer minted-2"}, topoAuths)
+}
+
+// TestSuppliedTokenWinsOverWorkloadIdentity asserts that a token supplied with
+// the request is the one that reaches the wire even when the pod carries an
+// ambient workload identity, and that no token exchange is attempted. Otherwise
+// the request would silently authenticate as the pod principal.
+func TestSuppliedTokenWinsOverWorkloadIdentity(t *testing.T) {
+	ctx := context.Background()
+	resetCredentialCache()
+
+	// A full workload-identity environment is present and must be ignored.
+	t.Setenv(envRoleLRN, "lrn:iam:identity:abc")
+	t.Setenv(envTokenFile, writeToken(t, "sa-jwt-value"))
+
+	const topoPage = `{"data":[
+		{"id":"i-1","networkPath":[{"id":"leaf1"},{"id":"spine1"}],"nvlink":null}
+	],"page_token":null}`
+
+	var exchangeHits int
+	var topoAuths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case oidcTokenPath:
+			exchangeHits++
+			_, _ = w.Write([]byte(`{"data":{"access_token":"minted-key","expires_in":3600}}`))
+		case apiPath:
+			topoAuths = append(topoAuths, r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(topoPage))
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	provider, httpErr := Loader(ctx, providers.Config{
+		Creds: map[string]any{
+			authWorkspaceID: "ws-1",
+			authToken:       "static-tok",
+		},
+		Params: map[string]any{apiBaseURL: server.URL},
+	})
+	require.Nil(t, httpErr)
+
+	graph, httpErr := provider.GenerateTopologyConfig(ctx, nil, []topology.ComputeInstances{
+		{Region: "stg-sjc01-cl03", Instances: map[string]string{"i-1": "node1"}},
+	})
+	require.Nil(t, httpErr)
+	require.NotNil(t, graph)
+
+	require.Equal(t, []string{"Bearer static-tok"}, topoAuths, "the supplied token must be used")
+	require.Equal(t, 0, exchangeHits, "no token exchange should be attempted")
+}
+
+// TestInstanceListStaleUnauthorizedKeepsRefreshedKey covers the race that
+// compare-and-invalidate exists for: a request is rejected while holding key 1,
+// but by the time its 401 comes back another request has already minted key 2.
+// Invalidating on behalf of the stale key must leave key 2 intact, otherwise the
+// valid replacement is wiped and every caller pays for a needless re-exchange.
+//
+// Ordering is deterministic without timers: the topology handler performs the
+// competing refresh inline before returning the 401, so the replacement is
+// guaranteed to be installed by the time InstanceList reacts to the rejection.
+func TestInstanceListStaleUnauthorizedKeepsRefreshedKey(t *testing.T) {
+	ctx := context.Background()
+	tokenPath := writeToken(t, "sa-jwt")
+
+	var (
+		mu         sync.Mutex
+		exchanges  int
+		topoAuths  []string
+		refreshTok string
+		refreshErr error
+	)
+	var cred *workloadIdentityCredential
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case oidcTokenPath:
+			mu.Lock()
+			exchanges++
+			n := exchanges
+			mu.Unlock()
+			_, _ = fmt.Fprintf(w, `{"data":{"access_token":"minted-%d","expires_in":3600}}`, n)
+		case apiPath:
+			auth := r.Header.Get("Authorization")
+			mu.Lock()
+			topoAuths = append(topoAuths, auth)
+			mu.Unlock()
+
+			if auth != "Bearer minted-1" {
+				_, _ = w.Write([]byte(`{"data":[{"id":"i-1","networkPath":[{"id":"leaf1"}],"nvlink":null}],"page_token":null}`))
+				return
+			}
+			// Stand in for a concurrent request that saw the 401 first and has
+			// already replaced the rejected key with a freshly minted one.
+			cred.InvalidateIfCurrent("minted-1")
+			tok, herr := cred.Token(ctx)
+			mu.Lock()
+			refreshTok = tok
+			if herr != nil {
+				refreshErr = herr
+			}
+			mu.Unlock()
+
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	cred = testCredential(server.URL, tokenPath, func() time.Time { return time.Unix(1_000_000, 0) })
+	client := &lambdaiClient{
+		baseURL:     server.URL,
+		token:       cred,
+		workspaceID: "ws-1",
+		pageSize:    defaultPageSize,
+	}
+
+	resp, err := client.InstanceList(ctx, &InstanceListRequest{Region: "r-1"})
+	require.NoError(t, err, "the retry with the replacement key should succeed")
+	require.Len(t, resp.Items, 1)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NoError(t, refreshErr)
+	require.Equal(t, "minted-2", refreshTok, "the competing refresh should have installed key 2")
+	require.Equal(t, []string{"Bearer minted-1", "Bearer minted-2"}, topoAuths,
+		"the retry must use the replacement key")
+	require.Equal(t, 2, exchanges,
+		"only two exchanges: a third means the stale 401 wiped the replacement key")
+
+	cred.mu.Lock()
+	defer cred.mu.Unlock()
+	require.NotNil(t, cred.cur, "the refreshed key must not have been cleared")
+	require.Equal(t, "minted-2", cred.cur.accessToken)
+}
+
+// TestStaticTokenDoesNotRetryOnUnauthorized asserts a rejected static token is
+// not re-minted or replayed -- only a workload-identity key is refreshable.
+func TestStaticTokenDoesNotRetryOnUnauthorized(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv(envRoleLRN, "")
+
+	var topoHits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, apiPath, r.URL.Path)
+		topoHits++
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	provider, httpErr := Loader(ctx, providers.Config{
+		Creds: map[string]any{
+			authWorkspaceID: "ws-1",
+			authToken:       "static-tok",
+		},
+		Params: map[string]any{apiBaseURL: server.URL},
+	})
+	require.Nil(t, httpErr)
+
+	_, httpErr = provider.GenerateTopologyConfig(ctx, nil, []topology.ComputeInstances{
+		{Region: "stg-sjc01-cl03", Instances: map[string]string{"i-1": "node1"}},
+	})
+	require.NotNil(t, httpErr)
+	require.Equal(t, 1, topoHits, "a static token must not be replayed on 401")
 }

--- a/pkg/providers/lambdai/provider_test.go
+++ b/pkg/providers/lambdai/provider_test.go
@@ -271,6 +271,38 @@ func TestLoader(t *testing.T) {
 			},
 			err: "credentials error: missing 'token'",
 		},
+		{
+			// Security: duplicate case-insensitive spellings both feed the same
+			// decoded field, and randomized map iteration picks the winner, so the
+			// ambiguity is reported rather than resolved arbitrarily.
+			name:    "Case 19: duplicate token spellings are rejected",
+			roleLRN: "lrn:iam:identity:abc",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": "workspace-123",
+					"token":       "token-abc",
+					"Token":       "token-xyz",
+				},
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+			err: "credentials error: ambiguous 'token' credential: Token, token",
+		},
+		{
+			name: "Case 20: duplicate workspaceId spellings are rejected",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": "workspace-123",
+					"WorkspaceID": "workspace-999",
+					"token":       "token-abc",
+				},
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+			err: "credentials error: ambiguous 'workspaceId' credential: WorkspaceID, workspaceId",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/providers/lambdai/token.go
+++ b/pkg/providers/lambdai/token.go
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 LAMBDA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package lambdai
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/NVIDIA/topograph/internal/httperr"
+	"github.com/NVIDIA/topograph/internal/httpreq"
+)
+
+const (
+	// Env vars injected by lambda-pod-identity-webhook into pods whose
+	// ServiceAccount carries the lambda.ai/role-lrn annotation.
+	envRoleLRN   = "LAMBDA_ROLE_LRN"
+	envTokenFile = "LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE"
+
+	// defaultSATokenPath matches where the webhook mounts the projected token;
+	// used only if envTokenFile is unset.
+	defaultSATokenPath = "/var/run/secrets/lambda.ai/serviceaccount/token"
+
+	oidcTokenPath = "/api/v1/oidc/token"
+
+	defaultTokenTTL   = 60 * time.Minute
+	defaultRefreshWin = 5 * time.Minute
+	defaultJitterFrac = 0.2
+)
+
+// tokenProvider yields a Lambda API bearer token. *httperr.Error preserves the
+// provider-boundary contract so the correct HTTP status propagates.
+type tokenProvider interface {
+	Token(ctx context.Context) (string, *httperr.Error)
+}
+
+// staticToken preserves the original static-credential behavior.
+type staticToken string
+
+func (s staticToken) Token(context.Context) (string, *httperr.Error) { return string(s), nil }
+
+// The provider Loader runs per request, but a workload-identity credential must
+// persist across requests so its token cache, single-flight refresh, and
+// graceful degradation take effect. Cache one credential per
+// (identityLRN, tokenPath, baseURL).
+var (
+	credMu    sync.Mutex
+	credCache = map[string]*workloadIdentityCredential{}
+)
+
+func sharedCredential(baseURL, identityLRN, tokenPath string) *workloadIdentityCredential {
+	key := identityLRN + "|" + tokenPath + "|" + baseURL
+	credMu.Lock()
+	defer credMu.Unlock()
+	if c, ok := credCache[key]; ok {
+		return c
+	}
+	c := &workloadIdentityCredential{
+		baseURL:       baseURL,
+		identityLRN:   identityLRN,
+		tokenPath:     tokenPath,
+		refreshWindow: defaultRefreshWin,
+		jitterFrac:    defaultJitterFrac,
+		now:           time.Now,
+	}
+	credCache[key] = c
+	return c
+}
+
+// resetCredentialCache clears the process-level cache. Test-only.
+func resetCredentialCache() {
+	credMu.Lock()
+	credCache = map[string]*workloadIdentityCredential{}
+	credMu.Unlock()
+}
+
+type cachedToken struct {
+	accessToken string
+	expiresAt   time.Time // hard deadline from the server
+	refreshAt   time.Time // when we begin refreshing, a little before expiry
+}
+
+// workloadIdentityCredential mints, caches, and refreshes a short-lived Lambda
+// API key by exchanging the pod's projected ServiceAccount JWT. Safe for
+// concurrent use. Ported from lambdal/ll-sdk-go PR #38, reimplemented over
+// internal/httpreq (no SDK dependency).
+type workloadIdentityCredential struct {
+	baseURL       string
+	identityLRN   string
+	tokenPath     string
+	refreshWindow time.Duration
+	jitterFrac    float64
+	now           func() time.Time // test seam; defaults to time.Now
+
+	mu        sync.RWMutex // guards cur
+	cur       *cachedToken
+	refreshMu sync.Mutex // one refresh at a time
+}
+
+func (c *workloadIdentityCredential) Token(ctx context.Context) (string, *httperr.Error) {
+	// Fast path: hand back the cached key if it isn't due for refresh.
+	c.mu.RLock()
+	cur := c.cur
+	c.mu.RUnlock()
+	if cur != nil && c.now().Before(cur.refreshAt) {
+		return cur.accessToken, nil
+	}
+
+	// One refresh at a time; everyone else reuses its result.
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+	c.mu.RLock()
+	cur = c.cur
+	c.mu.RUnlock()
+	if cur != nil && c.now().Before(cur.refreshAt) {
+		return cur.accessToken, nil
+	}
+
+	fresh, herr := c.exchangeOnce(ctx)
+	if herr != nil {
+		// A still-valid key survives a failed refresh; only a dead one errors.
+		if cur != nil && c.now().Before(cur.expiresAt) {
+			return cur.accessToken, nil
+		}
+		return "", herr
+	}
+	c.mu.Lock()
+	c.cur = &fresh
+	c.mu.Unlock()
+	return fresh.accessToken, nil
+}
+
+// InvalidateIfCurrent drops the cached key only when it still matches the token
+// that triggered the 401, preventing a concurrent refresh from being wiped by a
+// delayed response for an older key. The lock is held across both the comparison
+// and the clear, so a Token call that just installed a fresh key either happens
+// entirely before (and is seen as a mismatch) or entirely after.
+func (c *workloadIdentityCredential) InvalidateIfCurrent(token string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cur != nil && c.cur.accessToken == token {
+		c.cur = nil
+	}
+}
+
+func (c *workloadIdentityCredential) exchangeOnce(ctx context.Context) (cachedToken, *httperr.Error) {
+	// Re-read the file every mint: the kubelet rotates the projected token.
+	raw, err := os.ReadFile(c.tokenPath)
+	if err != nil {
+		return cachedToken{}, httperr.NewError(http.StatusInternalServerError,
+			fmt.Sprintf("failed to read service-account token %s: %v", c.tokenPath, err))
+	}
+	saToken := strings.TrimSpace(string(raw))
+	if saToken == "" {
+		return cachedToken{}, httperr.NewError(http.StatusInternalServerError,
+			fmt.Sprintf("service-account token %s is empty", c.tokenPath))
+	}
+
+	accessToken, expiresAt, herr := c.exchange(ctx, saToken)
+	if herr != nil {
+		return cachedToken{}, herr
+	}
+
+	// Refresh a bit before expiry (jittered) so a request never rides an
+	// expiring key and a fleet doesn't refresh in lockstep.
+	now := c.now()
+	window := c.refreshWindow
+	if life := expiresAt.Sub(now); window >= life {
+		window = life / 2
+	}
+	jitter := time.Duration(cryptoFloat64() * c.jitterFrac * float64(window))
+	refreshAt := expiresAt.Add(-(window - jitter))
+	if !refreshAt.After(now) {
+		refreshAt = now.Add(expiresAt.Sub(now) / 2)
+	}
+	return cachedToken{accessToken: accessToken, expiresAt: expiresAt, refreshAt: refreshAt}, nil
+}
+
+type exchangeRequest struct {
+	Token       string `json:"token"`
+	IdentityLRN string `json:"identity_lrn"`
+}
+
+type exchangeResponse struct {
+	Data struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+		ExpiresAt   string `json:"expires_at"`
+	} `json:"data"`
+}
+
+// exchange posts the ServiceAccount JWT to Lambda's OIDC endpoint. On failure it
+// returns an opaque error (Lambda returns a uniform 401 — "no oracle") and never
+// logs the JWT, the minted key, or the raw response body.
+func (c *workloadIdentityCredential) exchange(ctx context.Context, saToken string) (string, time.Time, *httperr.Error) {
+	payload, err := json.Marshal(exchangeRequest{Token: saToken, IdentityLRN: c.identityLRN})
+	if err != nil {
+		return "", time.Time{}, httperr.NewError(http.StatusInternalServerError, err.Error())
+	}
+	headers := map[string]string{"Content-Type": "application/json"}
+	f := httpreq.GetRequestFunc(ctx, http.MethodPost, headers, nil, payload, c.baseURL, oidcTokenPath)
+	body, herr := httpreq.DoRequestWithRetries(f, false)
+	if herr != nil {
+		klog.Warningf("lambda workload-identity token exchange failed (status %d) for identity %s", herr.Code(), c.identityLRN)
+		return "", time.Time{}, httperr.NewError(herr.Code(), "workload-identity token exchange failed")
+	}
+	var resp exchangeResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", time.Time{}, httperr.NewError(http.StatusBadGateway, err.Error())
+	}
+	if resp.Data.AccessToken == "" {
+		return "", time.Time{}, httperr.NewError(http.StatusBadGateway, "token exchange returned empty access_token")
+	}
+	return resp.Data.AccessToken, expiryOf(resp, c.now()), nil
+}
+
+// expiryOf prefers the absolute expires_at, falls back to expires_in, then a default.
+func expiryOf(resp exchangeResponse, now time.Time) time.Time {
+	if resp.Data.ExpiresAt != "" {
+		for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+			if t, err := time.Parse(layout, resp.Data.ExpiresAt); err == nil {
+				return t
+			}
+		}
+	}
+	if resp.Data.ExpiresIn > 0 {
+		return now.Add(time.Duration(resp.Data.ExpiresIn) * time.Second)
+	}
+	return now.Add(defaultTokenTTL)
+}
+
+// cryptoFloat64 returns a random float in [0,1) for refresh jitter only.
+func cryptoFloat64() float64 {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return 0 // no randomness: skip jitter rather than fail
+	}
+	return float64(binary.BigEndian.Uint64(b[:])>>11) / float64(1<<53)
+}

--- a/pkg/providers/lambdai/token.go
+++ b/pkg/providers/lambdai/token.go
@@ -38,6 +38,11 @@ const (
 	defaultTokenTTL   = 60 * time.Minute
 	defaultRefreshWin = 5 * time.Minute
 	defaultJitterFrac = 0.2
+
+	// failedRefreshBackoff defers the next exchange attempt after a failed
+	// refresh, so a burst of callers shares one outcome instead of each grinding
+	// through its own retry cycle while a usable cached key is still in hand.
+	failedRefreshBackoff = 30 * time.Second
 )
 
 // tokenProvider yields a Lambda API bearer token. *httperr.Error preserves the
@@ -55,9 +60,18 @@ func (s staticToken) Token(context.Context) (string, *httperr.Error) { return st
 // persist across requests so its token cache, single-flight refresh, and
 // graceful degradation take effect. Cache one credential per
 // (identityLRN, tokenPath, baseURL).
+//
+// identityLRN and tokenPath come from the pod environment and are therefore
+// fixed for the process, but baseURL is a per-request provider parameter, so the
+// key space is caller-controlled and must be bounded. Eviction is by insertion
+// order: dropping an entry costs one extra token exchange, whereas unbounded
+// growth is a slow leak. Real deployments hold exactly one entry.
+const maxCachedCredentials = 32
+
 var (
 	credMu    sync.Mutex
 	credCache = map[string]*workloadIdentityCredential{}
+	credOrder []string
 )
 
 func sharedCredential(baseURL, identityLRN, tokenPath string) *workloadIdentityCredential {
@@ -66,6 +80,10 @@ func sharedCredential(baseURL, identityLRN, tokenPath string) *workloadIdentityC
 	defer credMu.Unlock()
 	if c, ok := credCache[key]; ok {
 		return c
+	}
+	for len(credOrder) >= maxCachedCredentials {
+		delete(credCache, credOrder[0])
+		credOrder = credOrder[1:]
 	}
 	c := &workloadIdentityCredential{
 		baseURL:       baseURL,
@@ -76,14 +94,8 @@ func sharedCredential(baseURL, identityLRN, tokenPath string) *workloadIdentityC
 		now:           time.Now,
 	}
 	credCache[key] = c
+	credOrder = append(credOrder, key)
 	return c
-}
-
-// resetCredentialCache clears the process-level cache. Test-only.
-func resetCredentialCache() {
-	credMu.Lock()
-	credCache = map[string]*workloadIdentityCredential{}
-	credMu.Unlock()
 }
 
 type cachedToken struct {
@@ -132,6 +144,7 @@ func (c *workloadIdentityCredential) Token(ctx context.Context) (string, *httper
 	if herr != nil {
 		// A still-valid key survives a failed refresh; only a dead one errors.
 		if cur != nil && c.now().Before(cur.expiresAt) {
+			c.deferRefresh(cur, failedRefreshBackoff)
 			return cur.accessToken, nil
 		}
 		return "", herr
@@ -140,6 +153,34 @@ func (c *workloadIdentityCredential) Token(ctx context.Context) (string, *httper
 	c.cur = &fresh
 	c.mu.Unlock()
 	return fresh.accessToken, nil
+}
+
+// deferRefresh pushes the next refresh attempt out after a failed exchange, so
+// callers queued behind refreshMu reuse the still-valid cached key instead of
+// each running its own retry cycle against a failing endpoint. It never defers
+// past the hard expiry, since the key must still be re-minted before it dies.
+//
+// A copy is republished rather than the cached token mutated in place: Token
+// reads a published cachedToken after releasing the lock, so published values
+// must stay immutable.
+func (c *workloadIdentityCredential) deferRefresh(stale *cachedToken, d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cur == nil || c.cur != stale {
+		return // someone installed a fresh key meanwhile; leave theirs alone
+	}
+
+	next := c.now().Add(d)
+	if next.After(c.cur.expiresAt) {
+		next = c.cur.expiresAt
+	}
+	if !next.After(c.cur.refreshAt) {
+		return
+	}
+
+	updated := *c.cur
+	updated.refreshAt = next
+	c.cur = &updated
 }
 
 // InvalidateIfCurrent drops the cached key only when it still matches the token

--- a/pkg/providers/lambdai/token_test.go
+++ b/pkg/providers/lambdai/token_test.go
@@ -22,6 +22,15 @@ import (
 	"github.com/NVIDIA/topograph/internal/httperr"
 )
 
+// resetCredentialCache clears the process-level credential cache between tests.
+// Test-only, so it lives here rather than in the production file.
+func resetCredentialCache() {
+	credMu.Lock()
+	credCache = map[string]*workloadIdentityCredential{}
+	credOrder = nil
+	credMu.Unlock()
+}
+
 // writeToken writes contents to a fresh temp file and returns its path, standing
 // in for the webhook-projected ServiceAccount token volume.
 func writeToken(t *testing.T, contents string) string {
@@ -370,6 +379,92 @@ func TestWorkloadIdentityCredentialInvalidateIfCurrentIgnoresStale(t *testing.T)
 	require.Nil(t, herr)
 	require.Equal(t, current, again, "the newer key must survive a stale invalidation")
 	require.Equal(t, 2, hits, "a stale invalidation must not trigger a re-exchange")
+}
+
+// TestWorkloadIdentityCredentialFailedRefreshIsShared covers the burst case: once
+// a refresh fails while the cached key is still valid, later callers must reuse
+// that outcome instead of each grinding through their own retry cycle against the
+// failing endpoint.
+func TestWorkloadIdentityCredentialFailedRefreshIsShared(t *testing.T) {
+	ctx := context.Background()
+	tokenPath := writeToken(t, "jwt")
+
+	var mu sync.Mutex
+	var hits int
+	var fail bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits++
+		f := fail
+		mu.Unlock()
+		if f {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"access_token":"minted-1","expires_in":3600}}`))
+	}))
+	defer server.Close()
+
+	current := time.Unix(1_000_000, 0)
+	c := testCredential(server.URL, tokenPath, func() time.Time { return current })
+
+	tok, herr := c.Token(ctx)
+	require.Nil(t, herr)
+	require.Equal(t, "minted-1", tok)
+	mu.Lock()
+	require.Equal(t, 1, hits)
+	mu.Unlock()
+
+	// Past refreshAt (3300s) but before expiresAt (3600s), with the endpoint down.
+	current = current.Add(3400 * time.Second)
+	mu.Lock()
+	fail = true
+	mu.Unlock()
+
+	tok, herr = c.Token(ctx)
+	require.Nil(t, herr, "the still-valid key survives a failed refresh")
+	require.Equal(t, "minted-1", tok)
+	mu.Lock()
+	require.Equal(t, 2, hits, "one attempt for the failed refresh")
+	mu.Unlock()
+
+	// Subsequent callers inside the backoff must not attempt another exchange.
+	for range 5 {
+		tok, herr = c.Token(ctx)
+		require.Nil(t, herr)
+		require.Equal(t, "minted-1", tok)
+	}
+	mu.Lock()
+	require.Equal(t, 2, hits, "queued callers should share the failed refresh, not re-attempt")
+	mu.Unlock()
+
+	// The deferral never outlives the key: at expiry the exchange is retried.
+	current = current.Add(300 * time.Second) // now == expiresAt
+	_, _ = c.Token(ctx)
+	mu.Lock()
+	require.Greater(t, hits, 2, "an expired key must still trigger a fresh attempt")
+	mu.Unlock()
+}
+
+// TestSharedCredentialCacheIsBounded guards against unbounded growth: baseURL is
+// a caller-supplied provider parameter, so the cache key space is not closed.
+func TestSharedCredentialCacheIsBounded(t *testing.T) {
+	resetCredentialCache()
+	defer resetCredentialCache()
+
+	for i := range maxCachedCredentials + 20 {
+		sharedCredential(fmt.Sprintf("https://api-%d.example.com", i), "lrn:1", "/path/token")
+	}
+
+	credMu.Lock()
+	defer credMu.Unlock()
+	require.LessOrEqual(t, len(credCache), maxCachedCredentials, "cache must stay bounded")
+	require.Equal(t, len(credCache), len(credOrder), "eviction must keep map and order in step")
+	// FIFO: the oldest entries are the ones evicted.
+	_, oldestPresent := credCache["lrn:1|/path/token|https://api-0.example.com"]
+	require.False(t, oldestPresent, "the first inserted entry should have been evicted")
+	_, newestPresent := credCache[fmt.Sprintf("lrn:1|/path/token|https://api-%d.example.com", maxCachedCredentials+19)]
+	require.True(t, newestPresent, "the most recent entry should be retained")
 }
 
 func TestSharedCredentialCaching(t *testing.T) {

--- a/pkg/providers/lambdai/token_test.go
+++ b/pkg/providers/lambdai/token_test.go
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2026 LAMBDA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package lambdai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/topograph/internal/httperr"
+)
+
+// writeToken writes contents to a fresh temp file and returns its path, standing
+// in for the webhook-projected ServiceAccount token volume.
+func writeToken(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+// testCredential builds a workloadIdentityCredential with jitter disabled and an
+// injected clock for deterministic refresh timing.
+func testCredential(baseURL, tokenPath string, now func() time.Time) *workloadIdentityCredential {
+	return &workloadIdentityCredential{
+		baseURL:       baseURL,
+		identityLRN:   "lrn:iam:identity:abc",
+		tokenPath:     tokenPath,
+		refreshWindow: defaultRefreshWin,
+		jitterFrac:    0, // no jitter: deterministic refreshAt in tests
+		now:           now,
+	}
+}
+
+func TestStaticToken(t *testing.T) {
+	tok, herr := staticToken("tok-abc").Token(context.Background())
+	require.Nil(t, herr)
+	require.Equal(t, "tok-abc", tok)
+}
+
+func TestWorkloadIdentityCredentialExchange(t *testing.T) {
+	ctx := context.Background()
+
+	const saJWT = "header.payload.signature"
+	// Trailing whitespace must be trimmed before the JWT is sent.
+	tokenPath := writeToken(t, saJWT+"\n")
+
+	var hits int
+	var gotMethod, gotPath string
+	var gotBody exchangeRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"access_token":"minted-1","token_type":"Bearer","expires_in":3600}}`))
+	}))
+	defer server.Close()
+
+	fixed := time.Unix(1_000_000, 0)
+	c := testCredential(server.URL, tokenPath, func() time.Time { return fixed })
+
+	tok, herr := c.Token(ctx)
+	require.Nil(t, herr)
+	require.Equal(t, "minted-1", tok)
+
+	require.Equal(t, 1, hits)
+	require.Equal(t, http.MethodPost, gotMethod)
+	require.Equal(t, oidcTokenPath, gotPath)
+	require.Equal(t, saJWT, gotBody.Token)
+	require.Equal(t, "lrn:iam:identity:abc", gotBody.IdentityLRN)
+}
+
+func TestWorkloadIdentityCredentialCacheHit(t *testing.T) {
+	ctx := context.Background()
+	tokenPath := writeToken(t, "jwt")
+
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_, _ = w.Write([]byte(`{"data":{"access_token":"minted-1","expires_in":3600}}`))
+	}))
+	defer server.Close()
+
+	fixed := time.Unix(1_000_000, 0)
+	c := testCredential(server.URL, tokenPath, func() time.Time { return fixed })
+
+	t1, herr := c.Token(ctx)
+	require.Nil(t, herr)
+	t2, herr := c.Token(ctx)
+	require.Nil(t, herr)
+
+	require.Equal(t, "minted-1", t1)
+	require.Equal(t, t1, t2)
+	require.Equal(t, 1, hits, "second call should be served from cache")
+}
+
+func TestWorkloadIdentityCredentialRefresh(t *testing.T) {
+	ctx := context.Background()
+	tokenPath := writeToken(t, "jwt")
+
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_, _ = fmt.Fprintf(w, `{"data":{"access_token":"minted-%d","expires_in":3600}}`, hits)
+	}))
+	defer server.Close()
+
+	current := time.Unix(1_000_000, 0)
+	c := testCredential(server.URL, tokenPath, func() time.Time { return current })
+
+	t1, herr := c.Token(ctx)
+	require.Nil(t, herr)
+	require.Equal(t, "minted-1", t1)
+
+	// Advance past refreshAt (3600s expiry - 300s window, jitter 0 => 3300s).
+	current = current.Add(3400 * time.Second)
+
+	t2, herr := c.Token(ctx)
+	require.Nil(t, herr)
+	require.Equal(t, "minted-2", t2)
+	require.Equal(t, 2, hits, "expired key should be re-exchanged")
+}
+
+func TestWorkloadIdentityCredentialSingleFlight(t *testing.T) {
+	ctx := context.Background()
+	tokenPath := writeToken(t, "jwt")
+
+	var mu sync.Mutex
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits++
+		mu.Unlock()
+		// Hold the exchange open long enough for the fleet to pile up behind the
+		// single-flight lock.
+		time.Sleep(40 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"data":{"access_token":"minted-1","expires_in":3600}}`))
+	}))
+	defer server.Close()
+
+	fixed := time.Unix(1_000_000, 0)
+	c := testCredential(server.URL, tokenPath, func() time.Time { return fixed })
+
+	const goroutines = 25
+	var wg sync.WaitGroup
+	results := make([]string, goroutines)
+	errs := make([]*httperr.Error, goroutines)
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func() {
+			defer wg.Done()
+			results[i], errs[i] = c.Token(ctx)
+		}()
+	}
+	wg.Wait()
+
+	for i := range goroutines {
+		require.Nil(t, errs[i])
+		require.Equal(t, "minted-1", results[i])
+	}
+	mu.Lock()
+	require.Equal(t, 1, hits, "concurrent callers should share a single exchange")
+	mu.Unlock()
+}
+
+func TestWorkloadIdentityCredentialGracefulDegradation(t *testing.T) {
+	ctx := context.Background()
+	tokenPath := writeToken(t, "jwt")
+
+	var mu sync.Mutex
+	var fail bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		f := fail
+		mu.Unlock()
+		if f {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"access_token":"minted-1","expires_in":3600}}`))
+	}))
+	defer server.Close()
+
+	current := time.Unix(1_000_000, 0)
+	c := testCredential(server.URL, tokenPath, func() time.Time { return current })
+
+	// First mint succeeds.
+	tok, herr := c.Token(ctx)
+	require.Nil(t, herr)
+	require.Equal(t, "minted-1", tok)
+
+	// Past refreshAt (3300s) but before expiresAt (3600s): a failed refresh must
+	// still serve the cached, still-valid key.
+	current = current.Add(3400 * time.Second)
+	mu.Lock()
+	fail = true
+	mu.Unlock()
+
+	tok, herr = c.Token(ctx)
+	require.Nil(t, herr, "a still-valid key survives a failed refresh")
+	require.Equal(t, "minted-1", tok)
+
+	// Past expiresAt (now 3800s): the dead key surfaces the error.
+	current = current.Add(400 * time.Second)
+	tok, herr = c.Token(ctx)
+	require.NotNil(t, herr)
+	require.Equal(t, http.StatusUnauthorized, herr.Code())
+	require.Empty(t, tok)
+}
+
+func TestWorkloadIdentityCredentialExpiresAtPreferred(t *testing.T) {
+	ctx := context.Background()
+	tokenPath := writeToken(t, "jwt")
+
+	fixed := time.Unix(1_000_000, 0)
+	// Absolute expiry far in the future paired with a tiny expires_in: if
+	// expires_in were preferred, the key would already be due for refresh.
+	expiresAt := fixed.Add(10000 * time.Second).UTC().Format(time.RFC3339)
+
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_, _ = fmt.Fprintf(w, `{"data":{"access_token":"minted-%d","expires_in":1,"expires_at":%q}}`, hits, expiresAt)
+	}))
+	defer server.Close()
+
+	current := fixed
+	c := testCredential(server.URL, tokenPath, func() time.Time { return current })
+
+	t1, herr := c.Token(ctx)
+	require.Nil(t, herr)
+	require.Equal(t, "minted-1", t1)
+
+	// Advance well past what expires_in:1 would permit; expires_at keeps it fresh.
+	current = current.Add(2 * time.Second)
+	t2, herr := c.Token(ctx)
+	require.Nil(t, herr)
+	require.Equal(t, "minted-1", t2)
+	require.Equal(t, 1, hits, "absolute expires_at should be preferred over expires_in")
+}
+
+func TestWorkloadIdentityCredentialEmptyTokenFile(t *testing.T) {
+	ctx := context.Background()
+	tokenPath := writeToken(t, "   \n") // whitespace only -> empty after trim
+
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+	}))
+	defer server.Close()
+
+	c := testCredential(server.URL, tokenPath, func() time.Time { return time.Unix(1_000_000, 0) })
+
+	tok, herr := c.Token(ctx)
+	require.Empty(t, tok)
+	require.NotNil(t, herr)
+	require.Equal(t, http.StatusInternalServerError, herr.Code())
+	require.Equal(t, 0, hits, "an empty token must not attempt an exchange")
+}
+
+func TestWorkloadIdentityCredentialMissingFile(t *testing.T) {
+	ctx := context.Background()
+	c := testCredential(
+		"https://example.invalid",
+		filepath.Join(t.TempDir(), "does-not-exist"),
+		func() time.Time { return time.Unix(1_000_000, 0) },
+	)
+
+	tok, herr := c.Token(ctx)
+	require.Empty(t, tok)
+	require.NotNil(t, herr)
+	require.Equal(t, http.StatusInternalServerError, herr.Code())
+}
+
+func TestWorkloadIdentityCredentialUnauthorizedNoLeak(t *testing.T) {
+	ctx := context.Background()
+	const saJWT = "super-secret-jwt-value"
+	tokenPath := writeToken(t, saJWT)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized-detail"}`))
+	}))
+	defer server.Close()
+
+	c := testCredential(server.URL, tokenPath, func() time.Time { return time.Unix(1_000_000, 0) })
+
+	tok, herr := c.Token(ctx)
+	require.Empty(t, tok)
+	require.NotNil(t, herr)
+	require.Equal(t, http.StatusUnauthorized, herr.Code())
+	// The error must leak neither the JWT nor the raw response body.
+	require.NotContains(t, herr.Error(), saJWT)
+	require.NotContains(t, herr.Error(), "unauthorized-detail")
+}
+
+func TestWorkloadIdentityCredentialInvalidateIfCurrent(t *testing.T) {
+	ctx := context.Background()
+	tokenPath := writeToken(t, "jwt")
+
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_, _ = fmt.Fprintf(w, `{"data":{"access_token":"minted-%d","expires_in":3600}}`, hits)
+	}))
+	defer server.Close()
+
+	fixed := time.Unix(1_000_000, 0)
+	c := testCredential(server.URL, tokenPath, func() time.Time { return fixed })
+
+	t1, herr := c.Token(ctx)
+	require.Nil(t, herr)
+	require.Equal(t, "minted-1", t1)
+
+	c.InvalidateIfCurrent(t1)
+
+	t2, herr := c.Token(ctx)
+	require.Nil(t, herr)
+	require.Equal(t, "minted-2", t2)
+	require.Equal(t, 2, hits, "invalidating the current key should force a re-exchange")
+}
+
+// TestWorkloadIdentityCredentialInvalidateIfCurrentIgnoresStale covers the race where
+// a delayed 401 for an already-replaced key arrives after another request minted
+// a newer one: the stale invalidation must not discard the valid replacement.
+func TestWorkloadIdentityCredentialInvalidateIfCurrentIgnoresStale(t *testing.T) {
+	ctx := context.Background()
+	tokenPath := writeToken(t, "jwt")
+
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_, _ = fmt.Fprintf(w, `{"data":{"access_token":"minted-%d","expires_in":3600}}`, hits)
+	}))
+	defer server.Close()
+
+	fixed := time.Unix(1_000_000, 0)
+	c := testCredential(server.URL, tokenPath, func() time.Time { return fixed })
+
+	old, herr := c.Token(ctx)
+	require.Nil(t, herr)
+	require.Equal(t, "minted-1", old)
+
+	// Stand in for a concurrent refresh that installs a newer key.
+	c.InvalidateIfCurrent(old)
+	current, herr := c.Token(ctx)
+	require.Nil(t, herr)
+	require.Equal(t, "minted-2", current)
+	require.Equal(t, 2, hits)
+
+	// The delayed 401 for "minted-1" now lands; it must be a no-op.
+	c.InvalidateIfCurrent(old)
+
+	again, herr := c.Token(ctx)
+	require.Nil(t, herr)
+	require.Equal(t, current, again, "the newer key must survive a stale invalidation")
+	require.Equal(t, 2, hits, "a stale invalidation must not trigger a re-exchange")
+}
+
+func TestSharedCredentialCaching(t *testing.T) {
+	resetCredentialCache()
+
+	a := sharedCredential("https://api", "lrn:1", "/path/token")
+	b := sharedCredential("https://api", "lrn:1", "/path/token")
+	require.Same(t, a, b, "the same key returns the cached credential")
+
+	c := sharedCredential("https://api", "lrn:2", "/path/token")
+	require.NotSame(t, a, c, "a different identity is a different credential")
+
+	resetCredentialCache()
+	d := sharedCredential("https://api", "lrn:1", "/path/token")
+	require.NotSame(t, a, d, "reset clears the cache")
+}


### PR DESCRIPTION
Authenticate the lambdai provider with Kubernetes workload identity instead of a long-lived API token Secret. When lambda-pod-identity-webhook injects LAMBDA_ROLE_LRN and LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE into the pod, topograph exchanges the projected ServiceAccount token at POST /api/v1/oidc/token for a short-lived Lambda API key, caches it process-wide, and refreshes it before expiry (single-flight, jittered, and tolerant of a transient exchange failure while the cached key is valid).

Static-token mode is unchanged when LAMBDA_ROLE_LRN is absent.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
