### PR TITLE
feat: nscale api change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- The `nscale` provider's Slurm auto-discovery no longer requires a statically configured `placementId`. It now lists placements for the credentialed organization and region via the Nscale Placements API, then queries the Placement Servers API for each placement and merges the results into the instance-to-node map.
+
+### Removed
+
+- `nscale` provider `placementId` parameter — placements are discovered dynamically instead. `region` credential is now required whenever Slurm auto-discovery (`Instances2NodeMap`) is used.
+
 ### Added
 
 - Crusoe provider (`crusoe`) and its simulation variant (`crusoe-sim`) discover the InfiniBand switch fabric on Crusoe Cloud from the `crusoe.ai/ib.partition.id` and `crusoe.ai/pod.id` Node labels the Crusoe control plane publishes. Crusoe compute is virtualized, so a guest VM cannot run `ibnetdiscover` and there is no per-node metadata service for switch identity. Fabric tiers are the rail-optimized pod, the InfiniBand partition, and a synthetic root above them. Nodes without those labels are placed under placeholder tiers beneath the same root, so one Slurm tree spans a heterogeneous cluster. Use it with `topology/tree`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- The `nscale` provider's Slurm auto-discovery no longer requires a statically configured `placementId`. It now lists placements for the credentialed organization and region via the Nscale Placements API, then queries the Placement Servers API for each placement and merges the results into the instance-to-node map.
+- The `nscale` provider's Slurm auto-discovery runs `pdsh` across the current Slurm node list and queries each node's own Instance Metadata Service (IMDS) for its server ID (`serverID`) and region, merging the results into the instance-to-node and node-to-region maps.
+- The `nscale` provider's Radar API topology response field is now read as `server_id` instead of `instance_id`, matching the IMDS `serverID` field it is merged with.
+- The `nscale` provider's `region` credential, when set, now restricts Slurm auto-discovery to nodes whose IMDS region (`regionID`) matches it; nodes with a different or missing IMDS region are excluded from the topology query and logged as a warning.
 
 ### Removed
 
-- `nscale` provider `placementId` parameter — placements are discovered dynamically instead. `region` credential is now required whenever Slurm auto-discovery (`Instances2NodeMap`) is used.
+- `nscale` provider `instanceApiUrl` parameter and its instance API client — instance and region discovery for Slurm auto-discovery now comes from each node's IMDS instead.
 
 ### Added
 
 - Crusoe provider (`crusoe`) and its simulation variant (`crusoe-sim`) discover the InfiniBand switch fabric on Crusoe Cloud from the `crusoe.ai/ib.partition.id` and `crusoe.ai/pod.id` Node labels the Crusoe control plane publishes. Crusoe compute is virtualized, so a guest VM cannot run `ibnetdiscover` and there is no per-node metadata service for switch identity. Fabric tiers are the rail-optimized pod, the InfiniBand partition, and a synthetic root above them. Nodes without those labels are placed under placeholder tiers beneath the same root, so one Slurm tree spans a heterogeneous cluster. Use it with `topology/tree`.
+- Shared optional provider parameter `imdsUrl` (`providers.GetIMDSURL`, `topology.KeyIMDSURL`) for overriding a provider's default Instance Metadata Service URL. Only the `nscale` provider consumes it so far, falling back to its built-in IMDS URL when unset.
 - README badges replaced with a consistent flat-square Shields.io row: Docs, Go CI, Coverage, Chart Tests, K8s Tests, Release, and License — each linked to its source and using a shared dark label color aligned with the Topograph logo palette.
 - Documentation diagrams for architecture, Kubernetes, Slinky, Slurm topology formats, and engine outputs now ship as community-variant SVG and PNG assets with automatic dark/light mode switching (`<picture>` / `prefers-color-scheme` in docs; `#gh-light-mode-only` / `#gh-dark-mode-only` in README).
 - Topograph logo variants for light mode (`topograph-logo-color`), dark mode (`topograph-logo-color-dark`), reversed black, and reversed white added to `docs/assets/`. The `README.md` logo now switches between color and color-dark automatically based on the viewer's GitHub theme preference.
@@ -26,6 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - The `Go` workflow now also runs on pushes to `main`, so Codecov receives a coverage report for every merged commit. Merges are squashed, so the SHA that lands on `main` no longer matches the `pull-request/<n>` SHA that uploaded coverage; without a `main` trigger, Codecov's `main` branch had gone stale since 2026-07-06 and the README coverage badge reported a figure roughly six points below actual coverage.
+- `nscale` provider's Slurm auto-discovery now issues a single `pdsh` sweep to fetch IMDS metadata for the node list, instead of running it twice (once each for `Instances2NodeMap` and `GetInstancesRegions`).
+- `node-data-broker`'s per-node self-annotation for the `nscale` provider now honors the configured `imdsUrl` parameter instead of always querying the default IMDS endpoint, matching the Slurm auto-discovery path's behavior.
+- `nscale` provider's IMDS `pdsh` command no longer masks a failed `curl` behind `echo`'s always-zero exit status; a node whose IMDS request fails now reports that failure to `pdsh` instead of producing an empty response that silently drops the node.
 - GCP and OCI simulation providers now handle partial final pagination pages without indexing past the available instances.
 - Non-positive `pageSize` configuration values now emit a warning and use the provider default instead of reaching provider APIs and simulation pagination loops.
 

--- a/cmd/node-data-broker/main.go
+++ b/cmd/node-data-broker/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/NVIDIA/topograph/pkg/providers/infiniband"
 	"github.com/NVIDIA/topograph/pkg/providers/lambdai"
 	"github.com/NVIDIA/topograph/pkg/providers/nebius"
+	"github.com/NVIDIA/topograph/pkg/providers/nscale"
 	"github.com/NVIDIA/topograph/pkg/providers/oci"
 	"github.com/NVIDIA/topograph/pkg/topology"
 )
@@ -214,6 +215,8 @@ func (b *nodeBroker) getAnnotations(ctx context.Context) (map[string]string, err
 		return oci.GetNodeAnnotations(ctx)
 	case nebius.NAME:
 		return nebius.GetNodeAnnotations(ctx)
+	case nscale.NAME:
+		return nscale.GetNodeAnnotations(ctx, b.config.Provider.Params)
 	case dra.NAME:
 		return dra.GetNodeAnnotations(ctx, b.nodeName)
 	case infiniband.NAME_K8S:

--- a/cmd/node-data-broker/main_test.go
+++ b/cmd/node-data-broker/main_test.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/NVIDIA/topograph/pkg/providers/infiniband"
+	"github.com/NVIDIA/topograph/pkg/providers/nscale"
 	"github.com/NVIDIA/topograph/pkg/topology"
 )
 
@@ -216,5 +217,83 @@ func TestServeHealthShutsDownOnContextCancel(t *testing.T) {
 		require.NoError(t, err)
 	case <-time.After(5 * time.Second):
 		t.Fatal("serveHealth did not return after context cancellation")
+	}
+}
+
+// TestGetAnnotationsNscaleDispatch verifies that getAnnotations routes the
+// nscale.NAME provider to nscale.GetNodeAnnotations, forwarding the
+// configured imdsUrl provider param instead of touching the process-global
+// http.DefaultTransport. nscale.GetNodeAnnotations' own request/parse/
+// error-handling behavior (malformed IMDS response, context cancellation,
+// etc.) is covered by pkg/providers/nscale's own test suite (imds_test.go);
+// this test only needs to prove the switch reaches it with the configured
+// endpoint.
+func TestGetAnnotationsNscaleDispatch(t *testing.T) {
+	body := `{"meta": {"serverID": "srv-1", "regionID": "region-a"}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	broker := &nodeBroker{
+		config: nodeDataBrokerConfig{Provider: topology.Provider{
+			Name:   nscale.NAME,
+			Params: map[string]any{"imdsUrl": server.URL},
+		}},
+	}
+	annotations, err := broker.getAnnotations(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		topology.KeyNodeInstance: "srv-1",
+		topology.KeyNodeRegion:   "region-a",
+	}, annotations)
+}
+
+// TestGetAnnotationsNscaleDispatchCanceledContext verifies that a canceled
+// context passed into broker.getAnnotations propagates through the nscale
+// dispatch to the underlying IMDS request, returning promptly with an error
+// instead of hanging.
+func TestGetAnnotationsNscaleDispatchCanceledContext(t *testing.T) {
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-unblock
+		_, _ = w.Write([]byte(`{"meta": {"serverID": "srv-1"}}`))
+	}))
+	t.Cleanup(func() {
+		close(unblock)
+		server.Close()
+	})
+
+	broker := &nodeBroker{
+		config: nodeDataBrokerConfig{Provider: topology.Provider{
+			Name:   nscale.NAME,
+			Params: map[string]any{"imdsUrl": server.URL},
+		}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := broker.getAnnotations(ctx)
+		done <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not receive request before timeout")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("getAnnotations did not return after context cancellation")
 	}
 }

--- a/docs/providers/nscale.md
+++ b/docs/providers/nscale.md
@@ -2,27 +2,27 @@
 
 The `nscale` topology provider reads topology data from the Nscale Radar API and converts it into Topograph's canonical three-tier topology graph.
 
-The provider uses two Nscale APIs:
+The provider uses three Nscale APIs:
 
 - **Radar API**: returns each instance's network path via `GET /v1/topology`
-- **Placement Servers API**: returns server metadata via `GET /api/v2/placements/{placementID}/servers`
+- **Placements API**: lists the organization's placements in a region via `GET /api/v2/placements`
+- **Placement Servers API**: returns server metadata for a placement via `GET /api/v2/placements/{placementID}/servers`
 
-The Radar response supplies the provider instance ID, switch path, and optional block ID. The Placement Servers API response maps provider instance IDs to hostnames using `metadata.id` and `metadata.name`; this is used by the Slurm engine when Topograph discovers Slurm nodes automatically.
+The Radar response supplies the provider instance ID, switch path, and optional block ID. For Slurm auto-discovery, the provider lists every placement for the configured organization and region, then queries the Placement Servers API for each one and merges the results into a single instance-ID-to-hostname map using `metadata.id` and `metadata.name`.
 
 ## When to Use This Provider
 
 Use this provider for Nscale environments where Radar is the topology source. It is most commonly used with the Slurm engine to generate `topology.conf` from the current Slurm node list.
 
-If the request payload supplies explicit `nodes`, Topograph uses those instance ID to node name mappings directly. If `nodes` is omitted and the Slurm engine is used, Topograph runs `scontrol show nodes -o`, asks the Nscale Placement Servers API for the server catalog in the configured placement, and keeps entries whose `metadata.name` matches a Slurm node name.
+If the request payload supplies explicit `nodes`, Topograph uses those instance ID to node name mappings directly. If `nodes` is omitted and the Slurm engine is used, Topograph runs `scontrol show nodes -o`, lists the organization's placements in the configured region via the Nscale Placements API, and asks the Placement Servers API for the server catalog of each placement. When `scontrol` returns a non-empty node list, only entries whose `metadata.name` exactly matches a Slurm node name are kept; if the node list is empty, every placement-server mapping is kept.
 
 ## Prerequisites
 
 - A Radar API endpoint reachable from the Topograph host
-- A Placement Servers API endpoint reachable from the Topograph host
+- A Placements / Placement Servers API endpoint reachable from the Topograph host
 - An Nscale organization ID
-- An API token with permission to read topology and placement server metadata
+- An API token with permission to read topology, placements, and placement server metadata
 - The Nscale region ID for the cluster
-- The Nscale placement ID for the rack-scale group of servers
 - For Slurm auto-discovery, `scontrol` must be available to the Topograph process
 
 ## Credentials
@@ -30,8 +30,8 @@ If the request payload supplies explicit `nodes`, Topograph uses those instance 
 | Field | Required | Description |
 |---|---|---|
 | `org` | Yes | Nscale organization ID |
-| `token` | Yes | Bearer token used for Radar and Placement Servers API requests |
-| `region` | Required for Slurm auto-discovery | Nscale region ID used for Slurm region assignment |
+| `token` | Yes | Bearer token used for Radar, Placements, and Placement Servers API requests |
+| `region` | Required for Slurm auto-discovery | Nscale region ID used for Slurm region assignment and to scope the Placements API listing |
 
 Store credentials in a YAML file:
 
@@ -54,8 +54,7 @@ Credentials can also be supplied directly in the topology request payload under 
 | Field | Required | Description |
 |---|---|---|
 | `radarApiUrl` | Yes | Base URL for the Radar API, for example `https://radar.example.com` |
-| `instanceApiUrl` | Yes | Base URL for the Instance API, for example `https://api.example.com` |
-| `placementId` | Yes | Nscale placement ID used to scope the Placement Servers API request |
+| `instanceApiUrl` | Yes | Base URL for the Placements and Placement Servers APIs, for example `https://api.example.com` |
 | `trimTiers` | No | Number of highest topology tiers to trim from output. Defaults to `0` |
 
 The top-level Topograph `pageSize` setting controls pagination for the Radar topology request.
@@ -78,7 +77,6 @@ credentialsPath: /etc/topograph/nscale-credentials.yaml
 providerParams:
   radarApiUrl: https://radar.example.com
   instanceApiUrl: https://api.example.com
-  placementId: <PLACEMENT_ID>
 
 engineParams:
   plugin: topology/tree
@@ -98,8 +96,7 @@ Example request payload:
     },
     "params": {
       "radarApiUrl": "https://radar.example.com",
-      "instanceApiUrl": "https://api.example.com",
-      "placementId": "<PLACEMENT_ID>"
+      "instanceApiUrl": "https://api.example.com"
     }
   },
   "engine": {
@@ -124,8 +121,7 @@ If you already have the instance ID to hostname mapping, you can include it expl
     },
     "params": {
       "radarApiUrl": "https://radar.example.com",
-      "instanceApiUrl": "https://api.example.com",
-      "placementId": "<PLACEMENT_ID>"
+      "instanceApiUrl": "https://api.example.com"
     }
   },
   "engine": {
@@ -164,32 +160,74 @@ Each returned instance is translated as follows:
 | `network_node_path[2]` | Leaf tier |
 | `block_id` | Accelerator / NVLink domain |
 
-For Slurm auto-discovery, the provider fetches server metadata from the Placement Servers API:
+For Slurm auto-discovery, the provider first lists the organization's placements in the configured region from the Placements API:
+
+```text
+GET <instanceApiUrl>/api/v2/placements?organizationID=<org>&regionID=<region>
+Authorization: Bearer <token>
+```
+
+The response is an array of placement objects; the provider extracts `metadata.id` from each entry. It then fetches server metadata from the Placement Servers API for every placement ID returned:
 
 ```text
 GET <instanceApiUrl>/api/v2/placements/<placementId>/servers
 Authorization: Bearer <token>
 ```
 
-The response is an array of placement server objects. The provider extracts `metadata.id` (the server's unique identifier) and `metadata.name` (the hostname) from each entry and builds an instance-ID-to-hostname map.
+The response is an array of placement server objects. The provider extracts `metadata.id` (the server's unique identifier) and `metadata.name` (the hostname) from each entry and merges them across all placements into a single instance-ID-to-hostname map.
 
 It builds the same map produced by:
 
 ```bash
-curl -s -H "Authorization: Bearer $TOKEN" \
-  "$INSTANCE_API_URL/api/v2/placements/$PLACEMENT_ID/servers" \
-  | jq -r '.[] | "\(.metadata.id)\t\(.metadata.name)"'
+set -euo pipefail
+
+placement_ids=$(curl --fail --show-error --silent -H "Authorization: Bearer $TOKEN" \
+  "$INSTANCE_API_URL/api/v2/placements?organizationID=$ORG_ID&regionID=$REGION_ID" \
+  | jq -er '.[] | select(.metadata.id != "") | .metadata.id')
+
+for placement_id in $placement_ids; do
+  curl --fail --show-error --silent -H "Authorization: Bearer $TOKEN" \
+    "$INSTANCE_API_URL/api/v2/placements/$placement_id/servers" \
+    | jq -er '.[] | select(.metadata.id != "" and .metadata.name != "") | "\(.metadata.id)\t\(.metadata.name)"'
+done
 ```
 
 ## Verifying the Output
 
-First verify that the Placement Servers API returns the hostnames Slurm knows:
+When Slurm's node list (`scontrol show nodes -o`) is non-empty, `Instances2NodeMap`
+only keeps a Placement Server entry when its `metadata.name` is an exact match for a
+Slurm node name — there is no fuzzy or partial matching. If the node list is empty,
+no filtering is applied and every placement-server mapping is retained. Before
+triggering topology generation, compare the hostnames returned by the Placements and
+Placement Servers APIs against Slurm's own node list and fail if they differ:
 
 ```bash
-curl -s -H "Authorization: Bearer $TOKEN" \
-  "$INSTANCE_API_URL/api/v2/placements/$PLACEMENT_ID/servers" \
-  | jq -r '.[] | "\(.metadata.id)\t\(.metadata.name)"'
+set -euo pipefail
+
+slurm_nodes=$(scontrol show nodes -o | grep -oE 'NodeName=[^ ]+' | cut -d= -f2 | sort -u)
+[ -n "$slurm_nodes" ] || { echo "FAIL: scontrol returned no nodes"; exit 1; }
+
+placement_ids=$(curl --fail --show-error --silent -H "Authorization: Bearer $TOKEN" \
+  "$INSTANCE_API_URL/api/v2/placements?organizationID=$ORG_ID&regionID=$REGION_ID" \
+  | jq -er '.[] | select(.metadata.id != "") | .metadata.id')
+
+placement_hostnames=$(for placement_id in $placement_ids; do
+  curl --fail --show-error --silent -H "Authorization: Bearer $TOKEN" \
+    "$INSTANCE_API_URL/api/v2/placements/$placement_id/servers" \
+    | jq -er '.[] | select(.metadata.id != "" and .metadata.name != "") | .metadata.name'
+done | sort -u)
+
+if diff <(printf '%s\n' "$slurm_nodes") <(printf '%s\n' "$placement_hostnames"); then
+  echo "OK: Placement Server hostnames match Slurm's node list"
+else
+  echo "FAIL: Placement Server hostnames differ from Slurm's node list"
+  exit 1
+fi
 ```
+
+If the two lists differ, `Instances2NodeMap` will silently drop the mismatched nodes
+from the generated topology rather than erroring, so this check should be run before
+relying on Slurm auto-discovery.
 
 Then trigger topology generation:
 

--- a/docs/providers/nscale.md
+++ b/docs/providers/nscale.md
@@ -5,23 +5,24 @@ The `nscale` topology provider reads topology data from the Nscale Radar API and
 The provider uses two Nscale APIs:
 
 - **Radar API**: returns each instance's network path via `GET /v1/topology`
-- **Instance API**: returns instance metadata via `GET /v2/instances?organizationID=<org>&regionID=<region>`
+- **Placement Servers API**: returns server metadata via `GET /api/v2/placements/{placementID}/servers`
 
-The Radar response supplies the provider instance ID, switch path, and optional block ID. The Instance API response maps provider instance IDs to hostnames using `metadata.id` and `metadata.name`; this is used by the Slurm engine when Topograph discovers Slurm nodes automatically.
+The Radar response supplies the provider instance ID, switch path, and optional block ID. The Placement Servers API response maps provider instance IDs to hostnames using `metadata.id` and `metadata.name`; this is used by the Slurm engine when Topograph discovers Slurm nodes automatically.
 
 ## When to Use This Provider
 
 Use this provider for Nscale environments where Radar is the topology source. It is most commonly used with the Slurm engine to generate `topology.conf` from the current Slurm node list.
 
-If the request payload supplies explicit `nodes`, Topograph uses those instance ID to node name mappings directly. If `nodes` is omitted and the Slurm engine is used, Topograph runs `scontrol show nodes -o`, asks the Nscale Instance API for the instance catalog in the configured region, and keeps entries whose `metadata.name` matches a Slurm node name.
+If the request payload supplies explicit `nodes`, Topograph uses those instance ID to node name mappings directly. If `nodes` is omitted and the Slurm engine is used, Topograph runs `scontrol show nodes -o`, asks the Nscale Placement Servers API for the server catalog in the configured placement, and keeps entries whose `metadata.name` matches a Slurm node name.
 
 ## Prerequisites
 
 - A Radar API endpoint reachable from the Topograph host
-- An Instance API endpoint reachable from the Topograph host
+- A Placement Servers API endpoint reachable from the Topograph host
 - An Nscale organization ID
-- An API token with permission to read topology and instance metadata
+- An API token with permission to read topology and placement server metadata
 - The Nscale region ID for the cluster
+- The Nscale placement ID for the rack-scale group of servers
 - For Slurm auto-discovery, `scontrol` must be available to the Topograph process
 
 ## Credentials
@@ -29,8 +30,8 @@ If the request payload supplies explicit `nodes`, Topograph uses those instance 
 | Field | Required | Description |
 |---|---|---|
 | `org` | Yes | Nscale organization ID |
-| `token` | Yes | Bearer token used for Radar and Instance API requests |
-| `region` | Required for Slurm auto-discovery | Nscale region ID used for Instance API lookup and Slurm region assignment |
+| `token` | Yes | Bearer token used for Radar and Placement Servers API requests |
+| `region` | Required for Slurm auto-discovery | Nscale region ID used for Slurm region assignment |
 
 Store credentials in a YAML file:
 
@@ -54,6 +55,7 @@ Credentials can also be supplied directly in the topology request payload under 
 |---|---|---|
 | `radarApiUrl` | Yes | Base URL for the Radar API, for example `https://radar.example.com` |
 | `instanceApiUrl` | Yes | Base URL for the Instance API, for example `https://api.example.com` |
+| `placementId` | Yes | Nscale placement ID used to scope the Placement Servers API request |
 | `trimTiers` | No | Number of highest topology tiers to trim from output. Defaults to `0` |
 
 The top-level Topograph `pageSize` setting controls pagination for the Radar topology request.
@@ -76,6 +78,7 @@ credentialsPath: /etc/topograph/nscale-credentials.yaml
 providerParams:
   radarApiUrl: https://radar.example.com
   instanceApiUrl: https://api.example.com
+  placementId: <PLACEMENT_ID>
 
 engineParams:
   plugin: topology/tree
@@ -95,7 +98,8 @@ Example request payload:
     },
     "params": {
       "radarApiUrl": "https://radar.example.com",
-      "instanceApiUrl": "https://api.example.com"
+      "instanceApiUrl": "https://api.example.com",
+      "placementId": "<PLACEMENT_ID>"
     }
   },
   "engine": {
@@ -120,7 +124,8 @@ If you already have the instance ID to hostname mapping, you can include it expl
     },
     "params": {
       "radarApiUrl": "https://radar.example.com",
-      "instanceApiUrl": "https://api.example.com"
+      "instanceApiUrl": "https://api.example.com",
+      "placementId": "<PLACEMENT_ID>"
     }
   },
   "engine": {
@@ -159,28 +164,30 @@ Each returned instance is translated as follows:
 | `network_node_path[2]` | Leaf tier |
 | `block_id` | Accelerator / NVLink domain |
 
-For Slurm auto-discovery, the provider also fetches instance metadata:
+For Slurm auto-discovery, the provider fetches server metadata from the Placement Servers API:
 
 ```text
-GET <instanceApiUrl>/v2/instances?organizationID=<org>&regionID=<region>
+GET <instanceApiUrl>/api/v2/placements/<placementId>/servers
 Authorization: Bearer <token>
 ```
+
+The response is an array of placement server objects. The provider extracts `metadata.id` (the server's unique identifier) and `metadata.name` (the hostname) from each entry and builds an instance-ID-to-hostname map.
 
 It builds the same map produced by:
 
 ```bash
 curl -s -H "Authorization: Bearer $TOKEN" \
-  "$INSTANCE_API_URL/v2/instances?organizationID=$ORG&regionID=$REGION" \
+  "$INSTANCE_API_URL/api/v2/placements/$PLACEMENT_ID/servers" \
   | jq -r '.[] | "\(.metadata.id)\t\(.metadata.name)"'
 ```
 
 ## Verifying the Output
 
-First verify that the Instance API returns the hostnames Slurm knows:
+First verify that the Placement Servers API returns the hostnames Slurm knows:
 
 ```bash
 curl -s -H "Authorization: Bearer $TOKEN" \
-  "$INSTANCE_API_URL/v2/instances?organizationID=$ORG&regionID=$REGION" \
+  "$INSTANCE_API_URL/api/v2/placements/$PLACEMENT_ID/servers" \
   | jq -r '.[] | "\(.metadata.id)\t\(.metadata.name)"'
 ```
 

--- a/docs/providers/nscale.md
+++ b/docs/providers/nscale.md
@@ -2,36 +2,33 @@
 
 The `nscale` topology provider reads topology data from the Nscale Radar API and converts it into Topograph's canonical three-tier topology graph.
 
-The provider uses three Nscale APIs:
+The provider uses two Nscale data sources:
 
-- **Radar API**: returns each instance's network path via `GET /v1/topology`
-- **Placements API**: lists the organization's placements in a region via `GET /api/v2/placements`
-- **Placement Servers API**: returns server metadata for a placement via `GET /api/v2/placements/{placementID}/servers`
+- **Radar API**: returns each instance's network path via `GET /v2/topology`
+- **Instance Metadata Service (IMDS)**: each node exposes its own server ID and region at `http://169.254.169.254/openstack/latest/meta_data.json`
 
-The Radar response supplies the provider instance ID, switch path, and optional block ID. For Slurm auto-discovery, the provider lists every placement for the configured organization and region, then queries the Placement Servers API for each one and merges the results into a single instance-ID-to-hostname map using `metadata.id` and `metadata.name`.
+The Radar response supplies the provider server ID, switch path, and optional block ID. For Slurm auto-discovery, the provider reaches each Slurm node over `pdsh` (SSH-based) and queries that node's own IMDS endpoint to build the server-ID-to-hostname map. If the `region` credential is set, nodes whose IMDS region does not match it are excluded from the topology query.
 
 ## When to Use This Provider
 
 Use this provider for Nscale environments where Radar is the topology source. It is most commonly used with the Slurm engine to generate `topology.conf` from the current Slurm node list.
 
-If the request payload supplies explicit `nodes`, Topograph uses those instance ID to node name mappings directly. If `nodes` is omitted and the Slurm engine is used, Topograph runs `scontrol show nodes -o`, lists the organization's placements in the configured region via the Nscale Placements API, and asks the Placement Servers API for the server catalog of each placement. When `scontrol` returns a non-empty node list, only entries whose `metadata.name` exactly matches a Slurm node name are kept; if the node list is empty, every placement-server mapping is kept.
+If the request payload supplies explicit `nodes`, Topograph uses those server ID to node name mappings directly. If `nodes` is omitted and the Slurm engine is used, Topograph runs `scontrol show nodes -o` to get the Slurm node list, then uses `pdsh` to query each node's local IMDS endpoint for its server ID (`serverID`) and region (`regionID`), merging the results into a single server-ID-to-hostname map.
 
 ## Prerequisites
 
 - A Radar API endpoint reachable from the Topograph host
-- A Placements / Placement Servers API endpoint reachable from the Topograph host
 - An Nscale organization ID
-- An API token with permission to read topology, placements, and placement server metadata
-- The Nscale region ID for the cluster
-- For Slurm auto-discovery, `scontrol` must be available to the Topograph process
+- An API token with permission to read Radar topology data
+- For Slurm auto-discovery: `scontrol` and `pdsh` must be available to the Topograph process, with SSH access to every Slurm node, and each node must be able to reach the configured `imdsUrl` endpoint (`169.254.169.254` by default; see [Parameters](#parameters))
 
 ## Credentials
 
 | Field | Required | Description |
 |---|---|---|
 | `org` | Yes | Nscale organization ID |
-| `token` | Yes | Bearer token used for Radar, Placements, and Placement Servers API requests |
-| `region` | Required for Slurm auto-discovery | Nscale region ID used for Slurm region assignment and to scope the Placements API listing |
+| `token` | Yes | Bearer token used for Radar API requests |
+| `region` | No | Restricts Slurm auto-discovery to nodes whose IMDS region (`regionID`) matches. Nodes with a different or missing IMDS region are excluded from the topology query and logged as a warning. Unset means no filtering |
 
 Store credentials in a YAML file:
 
@@ -54,8 +51,8 @@ Credentials can also be supplied directly in the topology request payload under 
 | Field | Required | Description |
 |---|---|---|
 | `radarApiUrl` | Yes | Base URL for the Radar API, for example `https://radar.example.com` |
-| `instanceApiUrl` | Yes | Base URL for the Placements and Placement Servers APIs, for example `https://api.example.com` |
 | `trimTiers` | No | Number of highest topology tiers to trim from output. Defaults to `0` |
+| `imdsUrl` | No | Override for the IMDS URL queried by Slurm auto-discovery (`pdsh` on each Slurm node) and by the node-data-broker's own per-node self-query on Kubernetes. Defaults to `http://169.254.169.254/openstack/latest/meta_data.json` |
 
 The top-level Topograph `pageSize` setting controls pagination for the Radar topology request.
 
@@ -76,7 +73,6 @@ credentialsPath: /etc/topograph/nscale-credentials.yaml
 
 providerParams:
   radarApiUrl: https://radar.example.com
-  instanceApiUrl: https://api.example.com
 
 engineParams:
   plugin: topology/tree
@@ -95,8 +91,7 @@ Example request payload:
       "region": "<REGION_ID>"
     },
     "params": {
-      "radarApiUrl": "https://radar.example.com",
-      "instanceApiUrl": "https://api.example.com"
+      "radarApiUrl": "https://radar.example.com"
     }
   },
   "engine": {
@@ -108,7 +103,7 @@ Example request payload:
 }
 ```
 
-If you already have the instance ID to hostname mapping, you can include it explicitly:
+If you already have the server ID to hostname mapping, you can include it explicitly:
 
 ```json
 {
@@ -120,8 +115,7 @@ If you already have the instance ID to hostname mapping, you can include it expl
       "region": "<REGION_ID>"
     },
     "params": {
-      "radarApiUrl": "https://radar.example.com",
-      "instanceApiUrl": "https://api.example.com"
+      "radarApiUrl": "https://radar.example.com"
     }
   },
   "engine": {
@@ -131,8 +125,8 @@ If you already have the instance ID to hostname mapping, you can include it expl
     {
       "region": "<REGION_ID>",
       "instances": {
-        "<INSTANCE_ID_1>": "node001",
-        "<INSTANCE_ID_2>": "node002"
+        "<SERVER_ID_1>": "node001",
+        "<SERVER_ID_2>": "node002"
       }
     }
   ]
@@ -144,7 +138,7 @@ If you already have the instance ID to hostname mapping, you can include it expl
 For each region in the compute instance list, the provider fetches topology pages from Radar:
 
 ```text
-GET <radarApiUrl>/v1/topology?limit=<pageSize>&offset=<offset>
+GET <radarApiUrl>/v2/topology?limit=<pageSize>&offset=<offset>
 Authorization: Bearer <token>
 X-Organization: <org>
 X-Region: <region>
@@ -154,80 +148,56 @@ Each returned instance is translated as follows:
 
 | Radar field | Topograph field |
 |---|---|
-| `instance_id` | Instance ID |
+| `server_id` | Server ID |
 | `network_node_path[0]` | Core tier |
 | `network_node_path[1]` | Spine tier |
 | `network_node_path[2]` | Leaf tier |
 | `block_id` | Accelerator / NVLink domain |
 
-For Slurm auto-discovery, the provider first lists the organization's placements in the configured region from the Placements API:
-
-```text
-GET <instanceApiUrl>/api/v2/placements?organizationID=<org>&regionID=<region>
-Authorization: Bearer <token>
-```
-
-The response is an array of placement objects; the provider extracts `metadata.id` from each entry. It then fetches server metadata from the Placement Servers API for every placement ID returned:
-
-```text
-GET <instanceApiUrl>/api/v2/placements/<placementId>/servers
-Authorization: Bearer <token>
-```
-
-The response is an array of placement server objects. The provider extracts `metadata.id` (the server's unique identifier) and `metadata.name` (the hostname) from each entry and merges them across all placements into a single instance-ID-to-hostname map.
-
-It builds the same map produced by:
+For Slurm auto-discovery, the provider runs `scontrol show nodes -o` to get the current Slurm node list, then uses `pdsh` to run the following on every node in that list:
 
 ```bash
-set -euo pipefail
-
-placement_ids=$(curl --fail --show-error --silent -H "Authorization: Bearer $TOKEN" \
-  "$INSTANCE_API_URL/api/v2/placements?organizationID=$ORG_ID&regionID=$REGION_ID" \
-  | jq -er '.[] | select(.metadata.id != "") | .metadata.id')
-
-for placement_id in $placement_ids; do
-  curl --fail --show-error --silent -H "Authorization: Bearer $TOKEN" \
-    "$INSTANCE_API_URL/api/v2/placements/$placement_id/servers" \
-    | jq -er '.[] | select(.metadata.id != "" and .metadata.name != "") | "\(.metadata.id)\t\(.metadata.name)"'
-done
+res=$(curl -fsS -- http://169.254.169.254/openstack/latest/meta_data.json) && echo "$res"
 ```
+
+This single `pdsh` sweep is cached and shared by both the server-ID-to-hostname map and the region map, so a topology request only queries each node's IMDS once, not once per map. Each node's response is a JSON document with a `meta` map. The provider extracts two fields per node:
+
+| IMDS `meta` field | Purpose |
+|---|---|
+| `serverID` | Server ID, used as the key in the server-ID-to-hostname map and matched against the Radar API's `server_id` field |
+| `regionID` | Region, used to group nodes for region-scoped Radar topology requests |
+
+Nodes that omit `serverID`, or whose IMDS response fails to parse, are dropped from the map; a node's absence from `regionID` simply omits it from the region map. If the `region` credential is set, nodes whose `regionID` does not match it (including nodes missing `regionID`) are excluded from both maps entirely, with a warning logged per excluded node.
 
 ## Verifying the Output
 
-When Slurm's node list (`scontrol show nodes -o`) is non-empty, `Instances2NodeMap`
-only keeps a Placement Server entry when its `metadata.name` is an exact match for a
-Slurm node name — there is no fuzzy or partial matching. If the node list is empty,
-no filtering is applied and every placement-server mapping is retained. Before
-triggering topology generation, compare the hostnames returned by the Placements and
-Placement Servers APIs against Slurm's own node list and fail if they differ:
+You can reproduce the same server-ID-to-hostname map Topograph builds by running the equivalent `pdsh` command directly. Replace `imds_url` below with the configured `imdsUrl` parameter if you override the default. This command is **unfiltered** — it does not apply the `region` credential's filtering, so if `region` is set, Topograph's actual map may exclude nodes this command still lists; cross-check those nodes' `regionID` against the configured `region` by hand if needed:
 
 ```bash
-set -euo pipefail
+set -uo pipefail
+
+imds_url=http://169.254.169.254/openstack/latest/meta_data.json
 
 slurm_nodes=$(scontrol show nodes -o | grep -oE 'NodeName=[^ ]+' | cut -d= -f2 | sort -u)
-[ -n "$slurm_nodes" ] || { echo "FAIL: scontrol returned no nodes"; exit 1; }
+status=$?
+[ "$status" -eq 0 ] && [ -n "$slurm_nodes" ] || { echo "FAIL: scontrol returned no usable node list (exit $status)"; exit 1; }
 
-placement_ids=$(curl --fail --show-error --silent -H "Authorization: Bearer $TOKEN" \
-  "$INSTANCE_API_URL/api/v2/placements?organizationID=$ORG_ID&regionID=$REGION_ID" \
-  | jq -er '.[] | select(.metadata.id != "") | .metadata.id')
+mappings=$(pdsh -R ssh -w "$(echo "$slurm_nodes" | paste -sd,)" \
+  "res=\$(curl -fsS -- '$imds_url') && echo \"\$res\"" \
+  | while IFS=: read -r node json; do
+      server_id=$(echo "$json" | jq -er '.meta["serverID"] // empty' 2>/dev/null)
+      if [ -z "$server_id" ]; then
+        echo "WARN: $node did not return a valid serverID, skipping" >&2
+        continue
+      fi
+      printf '%s\t%s\n' "$server_id" "$node"
+    done)
 
-placement_hostnames=$(for placement_id in $placement_ids; do
-  curl --fail --show-error --silent -H "Authorization: Bearer $TOKEN" \
-    "$INSTANCE_API_URL/api/v2/placements/$placement_id/servers" \
-    | jq -er '.[] | select(.metadata.id != "" and .metadata.name != "") | .metadata.name'
-done | sort -u)
-
-if diff <(printf '%s\n' "$slurm_nodes") <(printf '%s\n' "$placement_hostnames"); then
-  echo "OK: Placement Server hostnames match Slurm's node list"
-else
-  echo "FAIL: Placement Server hostnames differ from Slurm's node list"
-  exit 1
-fi
+[ -n "$mappings" ] || { echo "FAIL: no usable serverID-to-node mappings produced"; exit 1; }
+printf '%s\n' "$mappings"
 ```
 
-If the two lists differ, `Instances2NodeMap` will silently drop the mismatched nodes
-from the generated topology rather than erroring, so this check should be run before
-relying on Slurm auto-discovery.
+A node that fails to respond, or whose IMDS response is missing `serverID`, is silently dropped from the generated topology rather than causing an error — run this check before relying on Slurm auto-discovery.
 
 Then trigger topology generation:
 

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -64,3 +64,55 @@ func Pdsh(ctx context.Context, cmd string, nodes []string, opts ...string) (*byt
 
 	return Exec(ctx, "pdsh", args, nil)
 }
+
+// pdshCommandTimeout bounds how long pdsh waits for a single remote command
+// to finish (pdsh -u). Without it, one node whose remote command hangs (e.g.
+// a curl to an unreachable/blackholed metadata endpoint) occupies a fanout
+// slot forever and eventually stalls the whole sweep.
+const pdshCommandTimeout = "10"
+
+// PdshTolerant behaves like Pdsh but is meant for sweeps across large,
+// heterogeneous fleets where a handful of nodes being down, unreachable, or
+// otherwise slow to respond is expected and should not fail the whole
+// sweep. It adds:
+//   - "-S": makes pdsh's own exit code reflect the worst remote exit code,
+//     so a total failure (e.g. every node rejecting SSH) is detectable.
+//   - "-u": kills any single remote command that runs past
+//     pdshCommandTimeout, so one hung node can't stall the entire sweep.
+//
+// Unlike Pdsh, a non-zero exit does not automatically fail the call: if
+// pdsh still produced output, that partial output is returned with the
+// failure logged as a warning, since some nodes having failed alongside
+// others succeeding is the normal case at fleet scale. Only a non-zero
+// exit with no output at all (e.g. every node failing, as when the
+// invoking user has no valid SSH key) is treated as a hard error.
+func PdshTolerant(ctx context.Context, cmd string, nodes []string, opts ...string) (*bytes.Buffer, error) {
+	args := []string{"-R", "ssh", "-S", "-u", pdshCommandTimeout}
+	if len(opts) != 0 {
+		args = append(args, opts...)
+	}
+	args = append(args, "-w", strings.Join(cluset.Compact(nodes), ","), cmd)
+
+	klog.V(2).Infof("Execute command %s", strings.Join(append([]string{"pdsh"}, args...), " "))
+	execCmd := exec.CommandContext(ctx, "pdsh", args...)
+	execCmd.Env = os.Environ()
+
+	var stdout, stderr bytes.Buffer
+	execCmd.Stdout = &stdout
+	execCmd.Stderr = &stderr
+
+	err := execCmd.Run()
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		strerr := strings.ReplaceAll(stderr.String(), "\n", " ")
+		if stdout.Len() > 0 {
+			klog.Warningf("pdsh reported remote failures, continuing with partial results: %s", strerr)
+			return &stdout, nil
+		}
+		klog.ErrorS(err, "failed to execute pdsh command", "stderr", strerr)
+		return nil, fmt.Errorf("pdsh failed: %s : %v", strerr, err)
+	}
+	return &stdout, nil
+}

--- a/pkg/providers/nscale/imds.go
+++ b/pkg/providers/nscale/imds.go
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package nscale
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	"github.com/NVIDIA/topograph/internal/exec"
+	"github.com/NVIDIA/topograph/pkg/providers"
+	"github.com/NVIDIA/topograph/pkg/topology"
+)
+
+const (
+	IMDSURL = "http://169.254.169.254/openstack/latest/meta_data.json"
+
+	metaKeyServerID = "serverID"
+	metaKeyRegionID = "regionID"
+)
+
+type imdsMetadata struct {
+	Meta map[string]string `json:"meta"`
+}
+
+func pdshCmd(url string) string {
+	return fmt.Sprintf("res=$(curl -fsS -- %s) && echo \"$res\"", shellQuote(url))
+}
+
+// shellQuote wraps s in single quotes for safe embedding in a POSIX shell
+// command, escaping any single quotes it contains.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// maxIMDSLineSize bounds the per-node line length parseIMDSOutput will
+// scan, so a pathological pdsh line does not silently truncate the output.
+const maxIMDSLineSize = 1 << 20 // 1 MiB
+
+func parseIMDSOutput(buff *bytes.Buffer) (map[string]*imdsMetadata, error) {
+	res := make(map[string]*imdsMetadata)
+	scanner := bufio.NewScanner(buff)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxIMDSLineSize)
+	for scanner.Scan() {
+		str := scanner.Text()
+		idx := strings.Index(str, ": ")
+		if idx == -1 {
+			continue
+		}
+		node, data := str[:idx], str[idx+2:]
+
+		metadata := &imdsMetadata{}
+		if err := json.Unmarshal([]byte(data), metadata); err != nil {
+			klog.Warningf("failed to parse IMDS response for node %s: %v", node, err)
+			continue
+		}
+		res[node] = metadata
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan IMDS output: %v", err)
+	}
+
+	return res, nil
+}
+
+func fetchIMDSMetadata(ctx context.Context, nodes []string, imdsURL string) (map[string]*imdsMetadata, error) {
+	stdout, err := exec.PdshTolerant(ctx, pdshCmd(imdsURL), nodes)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseIMDSOutput(stdout)
+}
+
+// filterByRegion drops nodes whose IMDS region does not match expectedRegion,
+// logging a warning for each one. An empty expectedRegion disables filtering.
+func filterByRegion(nodeMeta map[string]*imdsMetadata, expectedRegion string) map[string]*imdsMetadata {
+	if len(expectedRegion) == 0 {
+		return nodeMeta
+	}
+
+	filtered := make(map[string]*imdsMetadata, len(nodeMeta))
+	for node, metadata := range nodeMeta {
+		region := metadata.Meta[metaKeyRegionID]
+		if region != expectedRegion {
+			klog.Warningf("excluding node %s from topology query: IMDS region %q does not match configured region %q", node, region, expectedRegion)
+			continue
+		}
+		filtered[node] = metadata
+	}
+
+	return filtered
+}
+
+func instanceToNodeMap(nodeMeta map[string]*imdsMetadata) map[string]string {
+	i2n := make(map[string]string, len(nodeMeta))
+	for node, metadata := range nodeMeta {
+		serverID := metadata.Meta[metaKeyServerID]
+		if len(serverID) == 0 {
+			continue
+		}
+		i2n[serverID] = node
+	}
+
+	return i2n
+}
+
+func getRegions(nodeMeta map[string]*imdsMetadata) map[string]string {
+	regions := make(map[string]string, len(nodeMeta))
+	for node, metadata := range nodeMeta {
+		if region := metadata.Meta[metaKeyRegionID]; len(region) > 0 {
+			regions[node] = region
+		}
+	}
+
+	return regions
+}
+
+// GetNodeAnnotations queries the local IMDS endpoint for this node's server
+// ID and region. params is the provider's raw config parameters; an
+// 'imdsUrl' entry overrides the default IMDS endpoint.
+func GetNodeAnnotations(ctx context.Context, params map[string]any) (map[string]string, error) {
+	imdsURL, err := providers.GetIMDSURL(params)
+	if err != nil {
+		return nil, err
+	}
+	if len(imdsURL) == 0 {
+		imdsURL = IMDSURL
+	}
+
+	data, err := providers.HttpReq(ctx, http.MethodGet, imdsURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute IMDS request: %v", err)
+	}
+
+	metadata := &imdsMetadata{}
+	if err := json.Unmarshal([]byte(data), metadata); err != nil {
+		return nil, fmt.Errorf("failed to parse IMDS response: %v", err)
+	}
+
+	serverID := metadata.Meta[metaKeyServerID]
+	if len(serverID) == 0 {
+		return nil, fmt.Errorf("missing %q in IMDS response", metaKeyServerID)
+	}
+
+	annotations := map[string]string{
+		topology.KeyNodeInstance: serverID,
+	}
+
+	if region := metadata.Meta[metaKeyRegionID]; len(region) > 0 {
+		annotations[topology.KeyNodeRegion] = region
+	}
+
+	return annotations, nil
+}

--- a/pkg/providers/nscale/imds_test.go
+++ b/pkg/providers/nscale/imds_test.go
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package nscale
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/topograph/pkg/topology"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// mockIMDSServer starts a real HTTP server returning body for every request,
+// and redirects GetNodeAnnotations' hardcoded IMDSURL requests to it by
+// swapping http.DefaultTransport for the duration of the test.
+func mockIMDSServer(t *testing.T, body string) *int {
+	t.Helper()
+
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	target, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		require.Equal(t, http.MethodGet, req.Method)
+		require.Equal(t, IMDSURL, req.URL.String())
+
+		redirected := req.Clone(req.Context())
+		redirected.URL.Scheme = target.Scheme
+		redirected.URL.Host = target.Host
+		redirected.Host = target.Host
+
+		return oldTransport.RoundTrip(redirected)
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = oldTransport
+	})
+
+	return &calls
+}
+
+func TestGetNodeAnnotations(t *testing.T) {
+	body := `{
+		"uuid": "a839ab99-f2e2-4237-a822-688a47eca11d",
+		"meta": {
+			"regionID": "d0ba550d-1be4-4c4e-8ef9-3adb23b3fe3b",
+			"serverID": "3fa74ca0-efab-4c5c-b926-aa98bb834dec-000000"
+		}
+	}`
+	calls := mockIMDSServer(t, body)
+
+	annotations, err := GetNodeAnnotations(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		topology.KeyNodeInstance: "3fa74ca0-efab-4c5c-b926-aa98bb834dec-000000",
+		topology.KeyNodeRegion:   "d0ba550d-1be4-4c4e-8ef9-3adb23b3fe3b",
+	}, annotations)
+	require.Equal(t, 1, *calls)
+}
+
+func TestGetNodeAnnotationsCustomIMDSURL(t *testing.T) {
+	body := `{"meta": {"serverID": "srv-custom", "regionID": "region-custom"}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NotEqual(t, IMDSURL, r.URL.String())
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	annotations, err := GetNodeAnnotations(context.Background(), map[string]any{"imdsUrl": server.URL})
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		topology.KeyNodeInstance: "srv-custom",
+		topology.KeyNodeRegion:   "region-custom",
+	}, annotations)
+}
+
+func TestGetNodeAnnotationsInvalidIMDSUrlParam(t *testing.T) {
+	_, err := GetNodeAnnotations(context.Background(), map[string]any{"imdsUrl": 1})
+	require.ErrorContains(t, err, "invalid 'imdsUrl' value")
+}
+
+func TestGetNodeAnnotationsMissingServerID(t *testing.T) {
+	body := `{"meta": {"regionID": "d0ba550d-1be4-4c4e-8ef9-3adb23b3fe3b"}}`
+	mockIMDSServer(t, body)
+
+	_, err := GetNodeAnnotations(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestGetNodeAnnotationsMalformedResponse(t *testing.T) {
+	mockIMDSServer(t, `not valid json`)
+
+	_, err := GetNodeAnnotations(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestGetNodeAnnotationsCanceledContext(t *testing.T) {
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-unblock
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(func() {
+		close(unblock)
+		server.Close()
+	})
+
+	target, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		redirected := req.Clone(req.Context())
+		redirected.URL.Scheme = target.Scheme
+		redirected.URL.Host = target.Host
+		redirected.Host = target.Host
+		return oldTransport.RoundTrip(redirected)
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = oldTransport
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := GetNodeAnnotations(ctx, nil)
+		done <- err
+	}()
+
+	<-started
+	cancel()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("GetNodeAnnotations did not return after context cancellation")
+	}
+}
+
+func TestPdshCmd(t *testing.T) {
+	expected := fmt.Sprintf("res=$(curl -fsS -- '%s') && echo \"$res\"", IMDSURL)
+	require.Equal(t, expected, pdshCmd(IMDSURL))
+}
+
+func TestPdshCmdEscapesShellMetacharacters(t *testing.T) {
+	malicious := `http://example.com/x'; rm -rf / #`
+	cmd := pdshCmd(malicious)
+	require.Equal(t, `res=$(curl -fsS -- 'http://example.com/x'\''; rm -rf / #') && echo "$res"`, cmd)
+}
+
+func TestParseIMDSOutput(t *testing.T) {
+	input := `node1: {"meta": {"serverID": "psrv-1", "regionID": "region-a"}}
+node2: {"meta": {"serverID": "psrv-2"}}
+node3: not valid json
+malformed line without separator
+`
+	res, err := parseIMDSOutput(bytes.NewBufferString(input))
+	require.NoError(t, err)
+	require.Equal(t, map[string]*imdsMetadata{
+		"node1": {Meta: map[string]string{
+			metaKeyServerID: "psrv-1",
+			metaKeyRegionID: "region-a",
+		}},
+		"node2": {Meta: map[string]string{
+			metaKeyServerID: "psrv-2",
+		}},
+	}, res)
+}
+
+func TestParseIMDSOutputOversizedLine(t *testing.T) {
+	oversized := "node1: " + strings.Repeat("x", maxIMDSLineSize+1)
+	_, err := parseIMDSOutput(bytes.NewBufferString(oversized))
+	require.Error(t, err)
+}
+
+func TestInstanceToNodeMap(t *testing.T) {
+	nodeMeta := map[string]*imdsMetadata{
+		"node1": {Meta: map[string]string{
+			metaKeyServerID: "psrv-1",
+			metaKeyRegionID: "region-a",
+		}},
+		"node2": {Meta: map[string]string{
+			metaKeyServerID: "psrv-2",
+		}},
+		"node3": {Meta: map[string]string{}},
+	}
+
+	require.Equal(t, map[string]string{
+		"psrv-1": "node1",
+		"psrv-2": "node2",
+	}, instanceToNodeMap(nodeMeta))
+}
+
+func TestGetRegions(t *testing.T) {
+	nodeMeta := map[string]*imdsMetadata{
+		"node1": {Meta: map[string]string{
+			metaKeyServerID: "psrv-1",
+			metaKeyRegionID: "region-a",
+		}},
+		"node2": {Meta: map[string]string{
+			metaKeyServerID: "psrv-2",
+		}},
+	}
+
+	require.Equal(t, map[string]string{
+		"node1": "region-a",
+	}, getRegions(nodeMeta))
+}
+
+func TestFilterByRegion(t *testing.T) {
+	nodeMeta := map[string]*imdsMetadata{
+		"node1": {Meta: map[string]string{
+			metaKeyServerID: "psrv-1",
+			metaKeyRegionID: "region-a",
+		}},
+		"node2": {Meta: map[string]string{
+			metaKeyServerID: "psrv-2",
+			metaKeyRegionID: "region-b",
+		}},
+		"node3": {Meta: map[string]string{
+			metaKeyServerID: "psrv-3",
+		}},
+	}
+
+	t.Run("no expected region: no filtering", func(t *testing.T) {
+		require.Equal(t, nodeMeta, filterByRegion(nodeMeta, ""))
+	})
+
+	t.Run("expected region: mismatched and missing regions excluded", func(t *testing.T) {
+		require.Equal(t, map[string]*imdsMetadata{
+			"node1": nodeMeta["node1"],
+		}, filterByRegion(nodeMeta, "region-a"))
+	})
+
+	t.Run("expected region: no matches", func(t *testing.T) {
+		require.Empty(t, filterByRegion(nodeMeta, "region-c"))
+	})
+}

--- a/pkg/providers/nscale/instance_topology.go
+++ b/pkg/providers/nscale/instance_topology.go
@@ -7,7 +7,6 @@ package nscale
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"k8s.io/klog/v2"
@@ -47,7 +46,7 @@ func (p *baseProvider) generateRegionInstanceTopology(ctx context.Context, topo 
 	for {
 		resp, err := p.client.Topology(ctx, ci.Region, pageSize, offset)
 		if err != nil {
-			return httperr.NewError(http.StatusBadGateway, fmt.Sprintf("failed to get topology: %v", err))
+			return err
 		}
 
 		n := len(resp)
@@ -59,7 +58,7 @@ func (p *baseProvider) generateRegionInstanceTopology(ctx context.Context, topo 
 
 		for _, inst := range resp {
 			t := &topology.InstanceTopology{
-				InstanceID: inst.ID,
+				InstanceID: inst.ServerID,
 			}
 
 			t.FabricTiers = topology.RootFirstFabricTiers(inst.NetworkPath...)

--- a/pkg/providers/nscale/provider.go
+++ b/pkg/providers/nscale/provider.go
@@ -23,6 +23,7 @@ const (
 	NAME = "nscale"
 
 	urlTopologyPath         = "/v1/topology"
+	urlPlacementsPath       = "/api/v2/placements"
 	urlPlacementServersPath = "/api/v2/placements/%s/servers"
 )
 
@@ -35,7 +36,6 @@ type baseProvider struct {
 type ProviderParams struct {
 	RadarApiUrl    string `mapstructure:"radarApiUrl"`
 	InstanceAPIUrl string `mapstructure:"instanceApiUrl"`
-	PlacementID    string `mapstructure:"placementId"`
 	TrimTiers      int    `mapstructure:"trimTiers"`
 }
 
@@ -47,10 +47,11 @@ type Credentials struct {
 
 type Client interface {
 	Topology(context.Context, string, int, int) ([]InstanceTopology, error)
+	ListPlacements(ctx context.Context, org, region string) ([]string, error)
 	PlacementServers(context.Context, string) (map[string]string, error)
 }
 
-// nscaleClient is a topology and instance API client.
+// nscaleClient is a Radar topology, Placements, and Placement Servers API client.
 type nscaleClient struct {
 	radarAPIURL    string
 	instanceAPIURL string
@@ -68,6 +69,14 @@ type InstanceTopology struct {
 // TopologyResult represents the topology of a single instance.
 type TopologyResult struct {
 	Instances []InstanceTopology `json:"results"`
+}
+
+type placement struct {
+	Metadata placementMetadata `json:"metadata"`
+}
+
+type placementMetadata struct {
+	ID string `json:"id"`
 }
 
 type placementServer struct {
@@ -102,6 +111,37 @@ func (c *nscaleClient) Topology(ctx context.Context, region string, pageSize, of
 	}
 
 	return resp.Instances, nil
+}
+
+func (c *nscaleClient) ListPlacements(ctx context.Context, org, region string) ([]string, error) {
+	headers := map[string]string{
+		"Authorization": "Bearer " + c.token,
+	}
+	query := map[string]string{
+		"organizationID": org,
+		"regionID":       region,
+	}
+	f := httpreq.GetRequestFunc(ctx, http.MethodGet, headers, query, nil, c.instanceAPIURL, urlPlacementsPath)
+
+	body, httpErr := httpreq.DoRequestWithRetries(f, false)
+	if httpErr != nil {
+		return nil, httpErr
+	}
+
+	placements := []placement{}
+	if err := json.Unmarshal(body, &placements); err != nil {
+		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
+	}
+
+	ids := make([]string, 0, len(placements))
+	for _, p := range placements {
+		if p.Metadata.ID == "" {
+			continue
+		}
+		ids = append(ids, p.Metadata.ID)
+	}
+
+	return ids, nil
 }
 
 func (c *nscaleClient) PlacementServers(ctx context.Context, placementID string) (map[string]string, error) {
@@ -176,9 +216,6 @@ func getParams(params map[string]any) (*ProviderParams, error) {
 	if len(p.InstanceAPIUrl) == 0 {
 		return nil, fmt.Errorf("missing 'instanceApiUrl'")
 	}
-	if len(p.PlacementID) == 0 {
-		return nil, fmt.Errorf("missing 'placementId'")
-	}
 
 	return p, nil
 }
@@ -209,14 +246,26 @@ func (p *baseProvider) GenerateTopologyConfig(ctx context.Context, pageSize *int
 
 // Instances2NodeMap implements slurm.instanceMapper
 func (p *Provider) Instances2NodeMap(ctx context.Context, nodes []string) (map[string]string, error) {
-	if len(p.params.PlacementID) == 0 {
-		return nil, fmt.Errorf("missing 'placementId'")
+	if len(p.creds.Region) == 0 {
+		return nil, fmt.Errorf("missing 'region'")
 	}
 
-	instances, err := p.client.PlacementServers(ctx, p.params.PlacementID)
+	placementIDs, err := p.client.ListPlacements(ctx, p.creds.Org, p.creds.Region)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get placement servers: %v", err)
+		return nil, fmt.Errorf("failed to list placements: %w", err)
 	}
+
+	instances := make(map[string]string)
+	for _, placementID := range placementIDs {
+		servers, err := p.client.PlacementServers(ctx, placementID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get placement servers for placement %s: %w", placementID, err)
+		}
+		for id, node := range servers {
+			instances[id] = node
+		}
+	}
+
 	if len(nodes) == 0 {
 		return instances, nil
 	}

--- a/pkg/providers/nscale/provider.go
+++ b/pkg/providers/nscale/provider.go
@@ -10,7 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"strconv"
+	"sync"
 
 	"github.com/NVIDIA/topograph/internal/config"
 	"github.com/NVIDIA/topograph/internal/httperr"
@@ -22,46 +24,62 @@ import (
 const (
 	NAME = "nscale"
 
-	urlTopologyPath         = "/v1/topology"
-	urlPlacementsPath       = "/api/v2/placements"
-	urlPlacementServersPath = "/api/v2/placements/%s/servers"
+	urlTopologyPath = "/v2/topology"
 )
+
+type imdsFetchFunc func(ctx context.Context, nodes []string, imdsURL string) (map[string]*imdsMetadata, error)
+
+// imdsCall represents a single in-flight fetchIMDSMetadata load. Callers
+// that arrive while a load is in progress wait on done instead of issuing a
+// redundant pdsh sweep; a canceled ctx lets a waiter stop waiting without
+// affecting the in-flight load itself.
+type imdsCall struct {
+	done chan struct{}
+	data map[string]*imdsMetadata
+	err  error
+}
 
 type baseProvider struct {
 	params *ProviderParams
 	creds  *Credentials
 	client Client
+
+	imdsMu       sync.Mutex
+	imdsNodes    []string
+	imdsData     map[string]*imdsMetadata
+	imdsInFlight *imdsCall
+	imdsFetch    imdsFetchFunc
 }
 
 type ProviderParams struct {
-	RadarApiUrl    string `mapstructure:"radarApiUrl"`
-	InstanceAPIUrl string `mapstructure:"instanceApiUrl"`
-	TrimTiers      int    `mapstructure:"trimTiers"`
+	RadarApiUrl string `mapstructure:"radarApiUrl"`
+	TrimTiers   int    `mapstructure:"trimTiers"`
+	IMDSUrl     string `mapstructure:"-"`
 }
 
 type Credentials struct {
-	Org    string `mapstructure:"org"`
-	Token  string `mapstructure:"token"`
+	Org   string `mapstructure:"org"`
+	Token string `mapstructure:"token"`
+	// Region, when set, restricts Slurm auto-discovery to nodes whose IMDS
+	// region matches. Nodes whose IMDS region differs are excluded from the
+	// topology query and logged as a warning.
 	Region string `mapstructure:"region"`
 }
 
 type Client interface {
-	Topology(context.Context, string, int, int) ([]InstanceTopology, error)
-	ListPlacements(ctx context.Context, org, region string) ([]string, error)
-	PlacementServers(context.Context, string) (map[string]string, error)
+	Topology(context.Context, string, int, int) ([]InstanceTopology, *httperr.Error)
 }
 
-// nscaleClient is a Radar topology, Placements, and Placement Servers API client.
+// nscaleClient is a Radar topology API client.
 type nscaleClient struct {
-	radarAPIURL    string
-	instanceAPIURL string
-	org            string
-	token          string
+	radarAPIURL string
+	org         string
+	token       string
 }
 
 // InstanceTopology represents the topology of a single instance.
 type InstanceTopology struct {
-	ID          string   `json:"instance_id"`
+	ServerID    string   `json:"server_id"`
 	NetworkPath []string `json:"network_node_path"`
 	BlockID     *string  `json:"block_id,omitempty"`
 }
@@ -71,24 +89,7 @@ type TopologyResult struct {
 	Instances []InstanceTopology `json:"results"`
 }
 
-type placement struct {
-	Metadata placementMetadata `json:"metadata"`
-}
-
-type placementMetadata struct {
-	ID string `json:"id"`
-}
-
-type placementServer struct {
-	Metadata placementServerMetadata `json:"metadata"`
-}
-
-type placementServerMetadata struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-}
-
-func (c *nscaleClient) Topology(ctx context.Context, region string, pageSize, offset int) ([]InstanceTopology, error) {
+func (c *nscaleClient) Topology(ctx context.Context, region string, pageSize, offset int) ([]InstanceTopology, *httperr.Error) {
 	headers := map[string]string{
 		"Authorization":  "Bearer " + c.token,
 		"X-Organization": c.org,
@@ -113,65 +114,6 @@ func (c *nscaleClient) Topology(ctx context.Context, region string, pageSize, of
 	return resp.Instances, nil
 }
 
-func (c *nscaleClient) ListPlacements(ctx context.Context, org, region string) ([]string, error) {
-	headers := map[string]string{
-		"Authorization": "Bearer " + c.token,
-	}
-	query := map[string]string{
-		"organizationID": org,
-		"regionID":       region,
-	}
-	f := httpreq.GetRequestFunc(ctx, http.MethodGet, headers, query, nil, c.instanceAPIURL, urlPlacementsPath)
-
-	body, httpErr := httpreq.DoRequestWithRetries(f, false)
-	if httpErr != nil {
-		return nil, httpErr
-	}
-
-	placements := []placement{}
-	if err := json.Unmarshal(body, &placements); err != nil {
-		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
-	}
-
-	ids := make([]string, 0, len(placements))
-	for _, p := range placements {
-		if p.Metadata.ID == "" {
-			continue
-		}
-		ids = append(ids, p.Metadata.ID)
-	}
-
-	return ids, nil
-}
-
-func (c *nscaleClient) PlacementServers(ctx context.Context, placementID string) (map[string]string, error) {
-	headers := map[string]string{
-		"Authorization": "Bearer " + c.token,
-	}
-	path := fmt.Sprintf(urlPlacementServersPath, placementID)
-	f := httpreq.GetRequestFunc(ctx, http.MethodGet, headers, nil, nil, c.instanceAPIURL, path)
-
-	body, httpErr := httpreq.DoRequestWithRetries(f, false)
-	if httpErr != nil {
-		return nil, httpErr
-	}
-
-	servers := []placementServer{}
-	if err := json.Unmarshal(body, &servers); err != nil {
-		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
-	}
-
-	i2n := make(map[string]string, len(servers))
-	for _, s := range servers {
-		if s.Metadata.ID == "" || s.Metadata.Name == "" {
-			continue
-		}
-		i2n[s.Metadata.ID] = s.Metadata.Name
-	}
-
-	return i2n, nil
-}
-
 type Provider struct {
 	baseProvider
 }
@@ -194,13 +136,13 @@ func Loader(ctx context.Context, config providers.Config) (providers.Provider, *
 	return &Provider{
 		baseProvider: baseProvider{
 			client: &nscaleClient{
-				radarAPIURL:    params.RadarApiUrl,
-				instanceAPIURL: params.InstanceAPIUrl,
-				org:            creds.Org,
-				token:          creds.Token,
+				radarAPIURL: params.RadarApiUrl,
+				org:         creds.Org,
+				token:       creds.Token,
 			},
-			params: params,
-			creds:  creds,
+			params:    params,
+			creds:     creds,
+			imdsFetch: fetchIMDSMetadata,
 		},
 	}, nil
 }
@@ -213,9 +155,12 @@ func getParams(params map[string]any) (*ProviderParams, error) {
 	if len(p.RadarApiUrl) == 0 {
 		return nil, fmt.Errorf("missing 'radarApiUrl'")
 	}
-	if len(p.InstanceAPIUrl) == 0 {
-		return nil, fmt.Errorf("missing 'instanceApiUrl'")
+
+	imdsURL, err := providers.GetIMDSURL(params)
+	if err != nil {
+		return nil, err
 	}
+	p.IMDSUrl = imdsURL
 
 	return p, nil
 }
@@ -246,55 +191,107 @@ func (p *baseProvider) GenerateTopologyConfig(ctx context.Context, pageSize *int
 
 // Instances2NodeMap implements slurm.instanceMapper
 func (p *Provider) Instances2NodeMap(ctx context.Context, nodes []string) (map[string]string, error) {
-	if len(p.creds.Region) == 0 {
-		return nil, fmt.Errorf("missing 'region'")
-	}
-
-	placementIDs, err := p.client.ListPlacements(ctx, p.creds.Org, p.creds.Region)
+	nodeMeta, err := p.fetchIMDSMetadata(ctx, nodes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list placements: %w", err)
+		return nil, err
 	}
-
-	instances := make(map[string]string)
-	for _, placementID := range placementIDs {
-		servers, err := p.client.PlacementServers(ctx, placementID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get placement servers for placement %s: %w", placementID, err)
-		}
-		for id, node := range servers {
-			instances[id] = node
-		}
-	}
-
-	if len(nodes) == 0 {
-		return instances, nil
-	}
-
-	nodeSet := make(map[string]struct{}, len(nodes))
-	for _, node := range nodes {
-		nodeSet[node] = struct{}{}
-	}
-
-	i2n := make(map[string]string, len(instances))
-	for instanceID, node := range instances {
-		if _, ok := nodeSet[node]; ok {
-			i2n[instanceID] = node
-		}
-	}
-
-	return i2n, nil
+	return instanceToNodeMap(nodeMeta), nil
 }
 
 // GetInstancesRegions implements slurm.instanceMapper
 func (p *Provider) GetInstancesRegions(ctx context.Context, nodes []string) (map[string]string, error) {
-	if len(p.creds.Region) == 0 {
-		return nil, fmt.Errorf("missing 'region'")
+	nodeMeta, err := p.fetchIMDSMetadata(ctx, nodes)
+	if err != nil {
+		return nil, err
+	}
+	return getRegions(nodeMeta), nil
+}
+
+// fetchIMDSMetadata returns parsed IMDS metadata for the given nodes, caching
+// the result so that repeated calls with the same node list (as done by
+// Instances2NodeMap and GetInstancesRegions) issue a single pdsh sweep. Nodes
+// whose IMDS region does not match the configured 'region' credential are
+// excluded, with a warning logged per excluded node.
+//
+// imdsMu only guards the cache and the in-flight bookkeeping, never the pdsh
+// call itself: a caller that finds a load already in progress waits on that
+// call's done channel rather than holding the lock, so a canceled ctx lets
+// it stop waiting immediately instead of blocking for the full sweep.
+func (p *baseProvider) fetchIMDSMetadata(ctx context.Context, nodes []string) (map[string]*imdsMetadata, error) {
+	for {
+		p.imdsMu.Lock()
+		if p.imdsData != nil && slices.Equal(p.imdsNodes, nodes) {
+			data := p.imdsData
+			p.imdsMu.Unlock()
+			return data, nil
+		}
+
+		if call := p.imdsInFlight; call != nil {
+			p.imdsMu.Unlock()
+			select {
+			case <-call.done:
+				continue
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+
+		call := &imdsCall{done: make(chan struct{})}
+		p.imdsInFlight = call
+		p.imdsMu.Unlock()
+
+		p.runIMDSFetch(ctx, nodes, call)
+		return call.data, call.err
+	}
+}
+
+// runIMDSFetch executes the pdsh sweep for call outside imdsMu, then
+// publishes its result to the cache (on success) and wakes any waiters. The
+// cleanup runs via defer so a canceled ctx, an error, or a panic unwinding
+// through this frame all leave imdsInFlight cleared and call.done closed.
+func (p *baseProvider) runIMDSFetch(ctx context.Context, nodes []string, call *imdsCall) {
+	defer func() {
+		p.imdsMu.Lock()
+		if p.imdsInFlight == call {
+			p.imdsInFlight = nil
+		}
+		if call.err == nil {
+			p.imdsNodes = slices.Clone(nodes)
+			p.imdsData = call.data
+		}
+		p.imdsMu.Unlock()
+		close(call.done)
+	}()
+
+	nodeMeta, err := p.imdsFetchFunc()(ctx, nodes, p.imdsURL())
+	if err != nil {
+		call.err = err
+		return
 	}
 
-	res := make(map[string]string)
-	for _, node := range nodes {
-		res[node] = p.creds.Region
+	var expectedRegion string
+	if p.creds != nil {
+		expectedRegion = p.creds.Region
+	}
+	call.data = filterByRegion(nodeMeta, expectedRegion)
+}
+
+// imdsFetchFunc returns the configured IMDS loader, falling back to the
+// package-level fetchIMDSMetadata for a baseProvider constructed without
+// going through Loader.
+func (p *baseProvider) imdsFetchFunc() imdsFetchFunc {
+	if p.imdsFetch != nil {
+		return p.imdsFetch
+	}
+	return fetchIMDSMetadata
+}
+
+// imdsURL returns the configured 'imdsUrl' provider parameter, falling back
+// to the default IMDS endpoint when it is not set.
+func (p *baseProvider) imdsURL() string {
+	if p.params != nil && len(p.params.IMDSUrl) > 0 {
+		return p.params.IMDSUrl
 	}
 
-	return res, nil
+	return IMDSURL
 }

--- a/pkg/providers/nscale/provider.go
+++ b/pkg/providers/nscale/provider.go
@@ -22,8 +22,8 @@ import (
 const (
 	NAME = "nscale"
 
-	urlTopologyPath  = "/v1/topology"
-	urlInstancesPath = "/v2/instances"
+	urlTopologyPath         = "/v1/topology"
+	urlPlacementServersPath = "/api/v2/placements/%s/servers"
 )
 
 type baseProvider struct {
@@ -35,6 +35,7 @@ type baseProvider struct {
 type ProviderParams struct {
 	RadarApiUrl    string `mapstructure:"radarApiUrl"`
 	InstanceAPIUrl string `mapstructure:"instanceApiUrl"`
+	PlacementID    string `mapstructure:"placementId"`
 	TrimTiers      int    `mapstructure:"trimTiers"`
 }
 
@@ -46,7 +47,7 @@ type Credentials struct {
 
 type Client interface {
 	Topology(context.Context, string, int, int) ([]InstanceTopology, error)
-	Instances(context.Context, string) (map[string]string, error)
+	PlacementServers(context.Context, string) (map[string]string, error)
 }
 
 // nscaleClient is a topology and instance API client.
@@ -69,11 +70,11 @@ type TopologyResult struct {
 	Instances []InstanceTopology `json:"results"`
 }
 
-type instance struct {
-	Metadata instanceMetadata `json:"metadata"`
+type placementServer struct {
+	Metadata placementServerMetadata `json:"metadata"`
 }
 
-type instanceMetadata struct {
+type placementServerMetadata struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }
@@ -103,32 +104,29 @@ func (c *nscaleClient) Topology(ctx context.Context, region string, pageSize, of
 	return resp.Instances, nil
 }
 
-func (c *nscaleClient) Instances(ctx context.Context, region string) (map[string]string, error) {
+func (c *nscaleClient) PlacementServers(ctx context.Context, placementID string) (map[string]string, error) {
 	headers := map[string]string{
 		"Authorization": "Bearer " + c.token,
 	}
-	query := map[string]string{
-		"organizationID": c.org,
-		"regionID":       region,
-	}
-	f := httpreq.GetRequestFunc(ctx, http.MethodGet, headers, query, nil, c.instanceAPIURL, urlInstancesPath)
+	path := fmt.Sprintf(urlPlacementServersPath, placementID)
+	f := httpreq.GetRequestFunc(ctx, http.MethodGet, headers, nil, nil, c.instanceAPIURL, path)
 
 	body, httpErr := httpreq.DoRequestWithRetries(f, false)
 	if httpErr != nil {
 		return nil, httpErr
 	}
 
-	instances := []instance{}
-	if err := json.Unmarshal(body, &instances); err != nil {
+	servers := []placementServer{}
+	if err := json.Unmarshal(body, &servers); err != nil {
 		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
 	}
 
-	i2n := make(map[string]string, len(instances))
-	for _, instance := range instances {
-		if instance.Metadata.ID == "" || instance.Metadata.Name == "" {
+	i2n := make(map[string]string, len(servers))
+	for _, s := range servers {
+		if s.Metadata.ID == "" || s.Metadata.Name == "" {
 			continue
 		}
-		i2n[instance.Metadata.ID] = instance.Metadata.Name
+		i2n[s.Metadata.ID] = s.Metadata.Name
 	}
 
 	return i2n, nil
@@ -178,6 +176,9 @@ func getParams(params map[string]any) (*ProviderParams, error) {
 	if len(p.InstanceAPIUrl) == 0 {
 		return nil, fmt.Errorf("missing 'instanceApiUrl'")
 	}
+	if len(p.PlacementID) == 0 {
+		return nil, fmt.Errorf("missing 'placementId'")
+	}
 
 	return p, nil
 }
@@ -208,13 +209,13 @@ func (p *baseProvider) GenerateTopologyConfig(ctx context.Context, pageSize *int
 
 // Instances2NodeMap implements slurm.instanceMapper
 func (p *Provider) Instances2NodeMap(ctx context.Context, nodes []string) (map[string]string, error) {
-	if len(p.creds.Region) == 0 {
-		return nil, fmt.Errorf("missing 'region'")
+	if len(p.params.PlacementID) == 0 {
+		return nil, fmt.Errorf("missing 'placementId'")
 	}
 
-	instances, err := p.client.Instances(ctx, p.creds.Region)
+	instances, err := p.client.PlacementServers(ctx, p.params.PlacementID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get instances: %v", err)
+		return nil, fmt.Errorf("failed to get placement servers: %v", err)
 	}
 	if len(nodes) == 0 {
 		return instances, nil

--- a/pkg/providers/nscale/provider_sim.go
+++ b/pkg/providers/nscale/provider_sim.go
@@ -67,6 +67,10 @@ func (c *simClient) Topology(ctx context.Context, _ string, pageSize, offset int
 	return resp, nil
 }
 
+func (c *simClient) ListPlacements(_ context.Context, _, _ string) ([]string, error) {
+	return []string{"sim"}, nil
+}
+
 func (c *simClient) PlacementServers(_ context.Context, _ string) (map[string]string, error) {
 	i2n := make(map[string]string, len(c.model.Nodes))
 	for _, node := range c.model.Nodes {

--- a/pkg/providers/nscale/provider_sim.go
+++ b/pkg/providers/nscale/provider_sim.go
@@ -19,8 +19,7 @@ import (
 const (
 	NAME_SIM = "nscale-sim"
 
-	errNone = iota
-	errTopology
+	errTopology = iota
 )
 
 type simClient struct {
@@ -34,9 +33,9 @@ type simProvider struct {
 	*providers.BaseSimProvider
 }
 
-func (c *simClient) Topology(ctx context.Context, _ string, pageSize, offset int) ([]InstanceTopology, error) {
+func (c *simClient) Topology(ctx context.Context, _ string, pageSize, offset int) ([]InstanceTopology, *httperr.Error) {
 	if c.apiErr == errTopology {
-		return nil, providers.ErrAPIError
+		return nil, httperr.NewError(http.StatusBadGateway, providers.ErrAPIError.Error())
 	}
 
 	resp := make([]InstanceTopology, 0, pageSize)
@@ -53,7 +52,7 @@ func (c *simClient) Topology(ctx context.Context, _ string, pageSize, offset int
 			path[len(nl)-1-i] = v
 		}
 		instance := InstanceTopology{
-			ID:          node.ID,
+			ServerID:    node.ID,
 			NetworkPath: path,
 		}
 		domainID := node.AcceleratorDomain()
@@ -65,19 +64,6 @@ func (c *simClient) Topology(ctx context.Context, _ string, pageSize, offset int
 	}
 
 	return resp, nil
-}
-
-func (c *simClient) ListPlacements(_ context.Context, _, _ string) ([]string, error) {
-	return []string{"sim"}, nil
-}
-
-func (c *simClient) PlacementServers(_ context.Context, _ string) (map[string]string, error) {
-	i2n := make(map[string]string, len(c.model.Nodes))
-	for _, node := range c.model.Nodes {
-		i2n[node.ID] = node.ID
-	}
-
-	return i2n, nil
 }
 
 func NamedLoaderSim() (string, providers.Loader) {

--- a/pkg/providers/nscale/provider_sim.go
+++ b/pkg/providers/nscale/provider_sim.go
@@ -67,7 +67,7 @@ func (c *simClient) Topology(ctx context.Context, _ string, pageSize, offset int
 	return resp, nil
 }
 
-func (c *simClient) Instances(_ context.Context, _ string) (map[string]string, error) {
+func (c *simClient) PlacementServers(_ context.Context, _ string) (map[string]string, error) {
 	i2n := make(map[string]string, len(c.model.Nodes))
 	for _, node := range c.model.Nodes {
 		i2n[node.ID] = node.ID

--- a/pkg/providers/nscale/provider_sim_test.go
+++ b/pkg/providers/nscale/provider_sim_test.go
@@ -83,7 +83,7 @@ func TestProviderSim(t *testing.T) {
 				},
 			},
 			apiErr: errTopology,
-			err:    `failed to get topology: API error`,
+			err:    `API error`,
 		},
 		{
 			name:   "Case 5: valid cluster in tree format without pagination",

--- a/pkg/providers/nscale/provider_test.go
+++ b/pkg/providers/nscale/provider_test.go
@@ -7,10 +7,14 @@ package nscale
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/NVIDIA/topograph/internal/httperr"
 	"github.com/NVIDIA/topograph/pkg/providers"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +33,6 @@ func TestLoader(t *testing.T) {
 				Params: map[string]any{
 					"radarApiUrl":    "https://radar.test.com",
 					"instanceApiUrl": "https://instances.test.com",
-					"placementId":    "placement-1",
 				},
 				Creds: map[string]any{
 					"org":    "org",
@@ -43,7 +46,6 @@ func TestLoader(t *testing.T) {
 			config: providers.Config{
 				Params: map[string]any{
 					"instanceApiUrl": "https://instances.test.com",
-					"placementId":    "placement-1",
 				},
 				Creds: map[string]any{
 					"org":   "org",
@@ -57,7 +59,6 @@ func TestLoader(t *testing.T) {
 			config: providers.Config{
 				Params: map[string]any{
 					"radarApiUrl": "https://radar.test.com",
-					"placementId": "placement-1",
 				},
 				Creds: map[string]any{
 					"org":   "org",
@@ -67,26 +68,11 @@ func TestLoader(t *testing.T) {
 			err: "missing 'instanceApiUrl'",
 		},
 		{
-			name: "Case 4: missing placementId",
+			name: "Case 4: missing org",
 			config: providers.Config{
 				Params: map[string]any{
 					"radarApiUrl":    "https://radar.test.com",
 					"instanceApiUrl": "https://instances.test.com",
-				},
-				Creds: map[string]any{
-					"org":   "org",
-					"token": "token",
-				},
-			},
-			err: "missing 'placementId'",
-		},
-		{
-			name: "Case 5: missing org",
-			config: providers.Config{
-				Params: map[string]any{
-					"radarApiUrl":    "https://radar.test.com",
-					"instanceApiUrl": "https://instances.test.com",
-					"placementId":    "placement-1",
 				},
 				Creds: map[string]any{
 					"token": "token",
@@ -95,12 +81,11 @@ func TestLoader(t *testing.T) {
 			err: "missing 'org'",
 		},
 		{
-			name: "Case 6: missing token",
+			name: "Case 5: missing token",
 			config: providers.Config{
 				Params: map[string]any{
 					"radarApiUrl":    "https://radar.test.com",
 					"instanceApiUrl": "https://instances.test.com",
-					"placementId":    "placement-1",
 				},
 				Creds: map[string]any{
 					"org": "org",
@@ -127,11 +112,16 @@ func TestLoader(t *testing.T) {
 	}
 }
 
-const placementServersResponse = `[
+const placementsResponse = `[
+  {"metadata": {"id": "placement-1"}},
+  {"metadata": {"id": "placement-2"}}
+]`
+
+const placementServersResponseTmpl = `[
   {
     "metadata": {
-      "id": "psrv-7f3d9d5d2a7c4e32",
-      "name": "training-workers-0",
+      "id": "%s",
+      "name": "%s",
       "organizationId": "9a8c6370-4065-4d4a-9da0-7678df40cd9d",
       "projectId": "e36c058a-8eba-4f5b-91f4-f6ffb983795c",
       "creationTime": "2026-04-28T11:04:00Z",
@@ -142,33 +132,11 @@ const placementServersResponse = `[
     "status": {
       "regionId": "c7568e2d-f9ab-453d-9a3a-51375f78426b",
       "reservationId": "a64f9269-36e0-4312-b8d1-52d93d569b7b",
-      "placementId": "b8ce034e-fccb-4d6c-a0e0-af3e3f346715",
+      "placementId": "%s",
       "networkId": "61f0ad85-3001-41cb-824a-e6a047668dfe",
       "powerState": "Running",
       "privateIP": "10.0.0.12",
-      "publicIP": "203.0.113.12",
       "macAddress": "fa:16:3e:7c:11:8a"
-    }
-  },
-  {
-    "metadata": {
-      "id": "psrv-950ab3259a1443da",
-      "name": "training-workers-1",
-      "organizationId": "9a8c6370-4065-4d4a-9da0-7678df40cd9d",
-      "projectId": "e36c058a-8eba-4f5b-91f4-f6ffb983795c",
-      "creationTime": "2026-04-28T11:04:02Z",
-      "createdBy": "john.doe@example.com",
-      "provisioningStatus": "provisioned",
-      "healthStatus": "healthy"
-    },
-    "status": {
-      "regionId": "c7568e2d-f9ab-453d-9a3a-51375f78426b",
-      "reservationId": "a64f9269-36e0-4312-b8d1-52d93d569b7b",
-      "placementId": "b8ce034e-fccb-4d6c-a0e0-af3e3f346715",
-      "networkId": "61f0ad85-3001-41cb-824a-e6a047668dfe",
-      "powerState": "Running",
-      "privateIP": "10.0.0.13",
-      "macAddress": "fa:16:3e:11:70:2f"
     }
   }
 ]`
@@ -179,7 +147,6 @@ func newTestProvider(t *testing.T, ctx context.Context, serverURL string) *Provi
 		Params: map[string]any{
 			"radarApiUrl":    "https://radar.test.com",
 			"instanceApiUrl": serverURL,
-			"placementId":    "placement-1",
 		},
 		Creds: map[string]any{
 			"org":    "org",
@@ -196,12 +163,25 @@ func TestInstances2NodeMap(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
-		require.Equal(t, "/api/v2/placements/placement-1/servers", r.URL.Path)
 		require.Equal(t, "Bearer token", r.Header.Get("Authorization"))
 
 		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(placementServersResponse))
-		require.NoError(t, err)
+
+		switch r.URL.Path {
+		case "/api/v2/placements":
+			require.Equal(t, "org", r.URL.Query().Get("organizationID"))
+			require.Equal(t, "region", r.URL.Query().Get("regionID"))
+			_, err := w.Write([]byte(placementsResponse))
+			require.NoError(t, err)
+		case "/api/v2/placements/placement-1/servers":
+			_, err := fmt.Fprintf(w, placementServersResponseTmpl, "psrv-7f3d9d5d2a7c4e32", "training-workers-0", "placement-1")
+			require.NoError(t, err)
+		case "/api/v2/placements/placement-2/servers":
+			_, err := fmt.Fprintf(w, placementServersResponseTmpl, "psrv-950ab3259a1443da", "training-workers-1", "placement-2")
+			require.NoError(t, err)
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
 	}))
 	defer server.Close()
 
@@ -222,38 +202,196 @@ func TestInstances2NodeMap(t *testing.T) {
 	}, i2n)
 }
 
-func TestPlacementServersErrors(t *testing.T) {
+const placementServersMissingFieldsResponse = `[
+  {"metadata": {"id": "psrv-1", "name": "training-workers-0"}},
+  {"metadata": {"id": "", "name": "training-workers-1"}},
+  {"metadata": {"id": "psrv-2", "name": ""}},
+  {"metadata": {"id": "psrv-3", "name": "training-workers-2"}}
+]`
+
+func TestPlacementServers(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("excludes servers missing id or name", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(placementServersMissingFieldsResponse))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		c := &nscaleClient{instanceAPIURL: server.URL, token: "token"}
+		i2n, err := c.PlacementServers(ctx, "placement-1")
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{
+			"psrv-1": "training-workers-0",
+			"psrv-3": "training-workers-2",
+		}, i2n)
+	})
+
+	t.Run("malformed JSON returns an error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(`{not valid json`))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		c := &nscaleClient{instanceAPIURL: server.URL, token: "token"}
+		i2n, err := c.PlacementServers(ctx, "placement-1")
+		require.Error(t, err)
+		require.Nil(t, i2n)
+	})
+
+	t.Run("canceled context returns promptly without retries", func(t *testing.T) {
+		var requests int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&requests, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(placementsResponse))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		cancelCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		c := &nscaleClient{instanceAPIURL: server.URL, token: "token"}
+
+		start := time.Now()
+		i2n, err := c.PlacementServers(cancelCtx, "placement-1")
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		require.Nil(t, i2n)
+		require.Less(t, elapsed, time.Second, "canceled context should fail immediately, not retry with backoff")
+		require.Equal(t, int32(0), atomic.LoadInt32(&requests), "canceled context should not reach the server")
+	})
+}
+
+const placementsResponseWithEmptyID = `[
+  {"metadata": {"id": "placement-1"}},
+  {"metadata": {"id": ""}},
+  {"metadata": {"id": "placement-2"}}
+]`
+
+func TestListPlacements(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("excludes placements missing id", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(placementsResponseWithEmptyID))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		c := &nscaleClient{instanceAPIURL: server.URL, token: "token"}
+		ids, err := c.ListPlacements(ctx, "org", "region")
+		require.NoError(t, err)
+		require.Equal(t, []string{"placement-1", "placement-2"}, ids)
+	})
+
+	t.Run("empty list returns no ids and no error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(`[]`))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		c := &nscaleClient{instanceAPIURL: server.URL, token: "token"}
+		ids, err := c.ListPlacements(ctx, "org", "region")
+		require.NoError(t, err)
+		require.Empty(t, ids)
+	})
+
+	t.Run("malformed JSON returns HTTP 502", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(`{not valid json`))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		c := &nscaleClient{instanceAPIURL: server.URL, token: "token"}
+		ids, err := c.ListPlacements(ctx, "org", "region")
+		require.Error(t, err)
+		require.Nil(t, ids)
+
+		var httpErr *httperr.Error
+		require.ErrorAs(t, err, &httpErr)
+		require.Equal(t, http.StatusBadGateway, httpErr.Code())
+	})
+
+	t.Run("canceled context returns without issuing a request", func(t *testing.T) {
+		var requests int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&requests, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(placementsResponse))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		cancelCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		c := &nscaleClient{instanceAPIURL: server.URL, token: "token"}
+
+		start := time.Now()
+		ids, err := c.ListPlacements(cancelCtx, "org", "region")
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		require.Nil(t, ids)
+		require.Less(t, elapsed, time.Second, "canceled context should fail immediately, not retry with backoff")
+		require.Equal(t, int32(0), atomic.LoadInt32(&requests), "canceled context should not reach the server")
+	})
+}
+
+func TestInstances2NodeMapErrors(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name       string
-		statusCode int
-		body       string
+		name             string
+		failPlacements   bool
+		statusCode       int
+		body             string
+		wantErrSubstring string
 	}{
 		{
-			name:       "400 invalid request",
-			statusCode: http.StatusBadRequest,
-			body:       `{"error":"invalid_request","error_description":"request body invalid","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+			name:             "400 invalid request listing placements",
+			failPlacements:   true,
+			statusCode:       http.StatusBadRequest,
+			body:             `{"error":"invalid_request","error_description":"request body invalid","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+			wantErrSubstring: "failed to list placements",
 		},
 		{
-			name:       "401 authentication failed",
-			statusCode: http.StatusUnauthorized,
-			body:       `{"error":"access_denied","error_description":"authentication failed","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+			name:             "401 authentication failed listing placements",
+			failPlacements:   true,
+			statusCode:       http.StatusUnauthorized,
+			body:             `{"error":"access_denied","error_description":"authentication failed","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+			wantErrSubstring: "failed to list placements",
 		},
 		{
-			name:       "403 forbidden",
-			statusCode: http.StatusForbidden,
-			body:       `{"error":"forbidden","error_description":"user credentials do not have the required privileges","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+			name:             "404 not found listing placements",
+			failPlacements:   true,
+			statusCode:       http.StatusNotFound,
+			body:             `{"error":"not_found","error_description":"the requested resource does not exist","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+			wantErrSubstring: "failed to list placements",
 		},
 		{
-			name:       "404 not found",
-			statusCode: http.StatusNotFound,
-			body:       `{"error":"not_found","error_description":"the requested resource does not exist","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+			name:             "403 forbidden fetching placement servers",
+			statusCode:       http.StatusForbidden,
+			body:             `{"error":"forbidden","error_description":"user credentials do not have the required privileges","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+			wantErrSubstring: "failed to get placement servers",
 		},
 		{
-			name:       "500 server error",
-			statusCode: http.StatusInternalServerError,
-			body:       `{"error":"server_error","error_description":"failed to token claim","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+			name:             "500 server error fetching placement servers",
+			statusCode:       http.StatusInternalServerError,
+			body:             `{"error":"server_error","error_description":"failed to token claim","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+			wantErrSubstring: "failed to get placement servers",
 		},
 	}
 
@@ -261,6 +399,19 @@ func TestPlacementServersErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
+
+				if r.URL.Path == "/api/v2/placements" {
+					if tt.failPlacements {
+						w.WriteHeader(tt.statusCode)
+						_, err := w.Write([]byte(tt.body))
+						require.NoError(t, err)
+						return
+					}
+					_, err := w.Write([]byte(placementsResponse))
+					require.NoError(t, err)
+					return
+				}
+
 				w.WriteHeader(tt.statusCode)
 				_, err := w.Write([]byte(tt.body))
 				require.NoError(t, err)
@@ -269,7 +420,11 @@ func TestPlacementServersErrors(t *testing.T) {
 
 			p := newTestProvider(t, ctx, server.URL)
 			_, err := p.Instances2NodeMap(ctx, nil)
-			require.ErrorContains(t, err, "failed to get placement servers")
+			require.ErrorContains(t, err, tt.wantErrSubstring)
+
+			var httpErr *httperr.Error
+			require.ErrorAs(t, err, &httpErr)
+			require.Equal(t, tt.statusCode, httpErr.Code())
 		})
 	}
 }

--- a/pkg/providers/nscale/provider_test.go
+++ b/pkg/providers/nscale/provider_test.go
@@ -29,6 +29,7 @@ func TestLoader(t *testing.T) {
 				Params: map[string]any{
 					"radarApiUrl":    "https://radar.test.com",
 					"instanceApiUrl": "https://instances.test.com",
+					"placementId":    "placement-1",
 				},
 				Creds: map[string]any{
 					"org":    "org",
@@ -42,6 +43,7 @@ func TestLoader(t *testing.T) {
 			config: providers.Config{
 				Params: map[string]any{
 					"instanceApiUrl": "https://instances.test.com",
+					"placementId":    "placement-1",
 				},
 				Creds: map[string]any{
 					"org":   "org",
@@ -55,6 +57,7 @@ func TestLoader(t *testing.T) {
 			config: providers.Config{
 				Params: map[string]any{
 					"radarApiUrl": "https://radar.test.com",
+					"placementId": "placement-1",
 				},
 				Creds: map[string]any{
 					"org":   "org",
@@ -64,11 +67,26 @@ func TestLoader(t *testing.T) {
 			err: "missing 'instanceApiUrl'",
 		},
 		{
-			name: "Case 4: missing org",
+			name: "Case 4: missing placementId",
 			config: providers.Config{
 				Params: map[string]any{
 					"radarApiUrl":    "https://radar.test.com",
 					"instanceApiUrl": "https://instances.test.com",
+				},
+				Creds: map[string]any{
+					"org":   "org",
+					"token": "token",
+				},
+			},
+			err: "missing 'placementId'",
+		},
+		{
+			name: "Case 5: missing org",
+			config: providers.Config{
+				Params: map[string]any{
+					"radarApiUrl":    "https://radar.test.com",
+					"instanceApiUrl": "https://instances.test.com",
+					"placementId":    "placement-1",
 				},
 				Creds: map[string]any{
 					"token": "token",
@@ -77,11 +95,12 @@ func TestLoader(t *testing.T) {
 			err: "missing 'org'",
 		},
 		{
-			name: "Case 5: missing token",
+			name: "Case 6: missing token",
 			config: providers.Config{
 				Params: map[string]any{
 					"radarApiUrl":    "https://radar.test.com",
 					"instanceApiUrl": "https://instances.test.com",
+					"placementId":    "placement-1",
 				},
 				Creds: map[string]any{
 					"org": "org",
@@ -108,30 +127,59 @@ func TestLoader(t *testing.T) {
 	}
 }
 
-func TestInstances2NodeMap(t *testing.T) {
-	ctx := context.Background()
+const placementServersResponse = `[
+  {
+    "metadata": {
+      "id": "psrv-7f3d9d5d2a7c4e32",
+      "name": "training-workers-0",
+      "organizationId": "9a8c6370-4065-4d4a-9da0-7678df40cd9d",
+      "projectId": "e36c058a-8eba-4f5b-91f4-f6ffb983795c",
+      "creationTime": "2026-04-28T11:04:00Z",
+      "createdBy": "john.doe@example.com",
+      "provisioningStatus": "provisioned",
+      "healthStatus": "healthy"
+    },
+    "status": {
+      "regionId": "c7568e2d-f9ab-453d-9a3a-51375f78426b",
+      "reservationId": "a64f9269-36e0-4312-b8d1-52d93d569b7b",
+      "placementId": "b8ce034e-fccb-4d6c-a0e0-af3e3f346715",
+      "networkId": "61f0ad85-3001-41cb-824a-e6a047668dfe",
+      "powerState": "Running",
+      "privateIP": "10.0.0.12",
+      "publicIP": "203.0.113.12",
+      "macAddress": "fa:16:3e:7c:11:8a"
+    }
+  },
+  {
+    "metadata": {
+      "id": "psrv-950ab3259a1443da",
+      "name": "training-workers-1",
+      "organizationId": "9a8c6370-4065-4d4a-9da0-7678df40cd9d",
+      "projectId": "e36c058a-8eba-4f5b-91f4-f6ffb983795c",
+      "creationTime": "2026-04-28T11:04:02Z",
+      "createdBy": "john.doe@example.com",
+      "provisioningStatus": "provisioned",
+      "healthStatus": "healthy"
+    },
+    "status": {
+      "regionId": "c7568e2d-f9ab-453d-9a3a-51375f78426b",
+      "reservationId": "a64f9269-36e0-4312-b8d1-52d93d569b7b",
+      "placementId": "b8ce034e-fccb-4d6c-a0e0-af3e3f346715",
+      "networkId": "61f0ad85-3001-41cb-824a-e6a047668dfe",
+      "powerState": "Running",
+      "privateIP": "10.0.0.13",
+      "macAddress": "fa:16:3e:11:70:2f"
+    }
+  }
+]`
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodGet, r.Method)
-		require.Equal(t, "/v2/instances", r.URL.Path)
-		require.Equal(t, "org", r.URL.Query().Get("organizationID"))
-		require.Equal(t, "region", r.URL.Query().Get("regionID"))
-		require.Equal(t, "Bearer token", r.Header.Get("Authorization"))
-
-		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`[
-			{"metadata":{"id":"instance-1","name":"node-1"}},
-			{"metadata":{"id":"instance-2","name":"node-2"}},
-			{"metadata":{"id":"instance-3","name":"outside-node"}}
-		]`))
-		require.NoError(t, err)
-	}))
-	defer server.Close()
-
+func newTestProvider(t *testing.T, ctx context.Context, serverURL string) *Provider {
+	t.Helper()
 	provider, httpErr := Loader(ctx, providers.Config{
 		Params: map[string]any{
 			"radarApiUrl":    "https://radar.test.com",
-			"instanceApiUrl": server.URL,
+			"instanceApiUrl": serverURL,
+			"placementId":    "placement-1",
 		},
 		Creds: map[string]any{
 			"org":    "org",
@@ -140,34 +188,88 @@ func TestInstances2NodeMap(t *testing.T) {
 		},
 	})
 	require.Nil(t, httpErr)
+	return provider.(*Provider)
+}
 
-	i2n, err := provider.(*Provider).Instances2NodeMap(ctx, []string{"node-1", "node-2"})
+func TestInstances2NodeMap(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v2/placements/placement-1/servers", r.URL.Path)
+		require.Equal(t, "Bearer token", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(placementServersResponse))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, ctx, server.URL)
+
+	i2n, err := p.Instances2NodeMap(ctx, []string{"training-workers-0", "training-workers-1"})
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{
-		"instance-1": "node-1",
-		"instance-2": "node-2",
+		"psrv-7f3d9d5d2a7c4e32": "training-workers-0",
+		"psrv-950ab3259a1443da": "training-workers-1",
 	}, i2n)
 
-	i2n, err = provider.(*Provider).Instances2NodeMap(ctx, nil)
+	i2n, err = p.Instances2NodeMap(ctx, nil)
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{
-		"instance-1": "node-1",
-		"instance-2": "node-2",
-		"instance-3": "outside-node",
+		"psrv-7f3d9d5d2a7c4e32": "training-workers-0",
+		"psrv-950ab3259a1443da": "training-workers-1",
 	}, i2n)
+}
 
-	provider, httpErr = Loader(ctx, providers.Config{
-		Params: map[string]any{
-			"radarApiUrl":    "https://radar.test.com",
-			"instanceApiUrl": server.URL,
-		},
-		Creds: map[string]any{
-			"org":   "org",
-			"token": "token",
-		},
-	})
-	require.Nil(t, httpErr)
+func TestPlacementServersErrors(t *testing.T) {
+	ctx := context.Background()
 
-	_, err = provider.(*Provider).Instances2NodeMap(ctx, []string{"node-1"})
-	require.EqualError(t, err, "missing 'region'")
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{
+			name:       "400 invalid request",
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":"invalid_request","error_description":"request body invalid","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+		},
+		{
+			name:       "401 authentication failed",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":"access_denied","error_description":"authentication failed","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+		},
+		{
+			name:       "403 forbidden",
+			statusCode: http.StatusForbidden,
+			body:       `{"error":"forbidden","error_description":"user credentials do not have the required privileges","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+		},
+		{
+			name:       "404 not found",
+			statusCode: http.StatusNotFound,
+			body:       `{"error":"not_found","error_description":"the requested resource does not exist","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+		},
+		{
+			name:       "500 server error",
+			statusCode: http.StatusInternalServerError,
+			body:       `{"error":"server_error","error_description":"failed to token claim","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_, err := w.Write([]byte(tt.body))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			p := newTestProvider(t, ctx, server.URL)
+			_, err := p.Instances2NodeMap(ctx, nil)
+			require.ErrorContains(t, err, "failed to get placement servers")
+		})
+	}
 }

--- a/pkg/providers/nscale/provider_test.go
+++ b/pkg/providers/nscale/provider_test.go
@@ -7,17 +7,36 @@ package nscale
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/NVIDIA/topograph/internal/httperr"
 	"github.com/NVIDIA/topograph/pkg/providers"
+	"github.com/NVIDIA/topograph/pkg/topology"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeClient struct {
+	instances []InstanceTopology
+	err       *httperr.Error
+	regions   []string
+}
+
+func (c *fakeClient) Topology(_ context.Context, region string, _, offset int) ([]InstanceTopology, *httperr.Error) {
+	c.regions = append(c.regions, region)
+	if c.err != nil {
+		return nil, c.err
+	}
+	if offset >= len(c.instances) {
+		return nil, nil
+	}
+	return c.instances[offset:], nil
+}
 
 func TestLoader(t *testing.T) {
 	ctx := context.Background()
@@ -31,8 +50,21 @@ func TestLoader(t *testing.T) {
 			name: "Case 1: success",
 			config: providers.Config{
 				Params: map[string]any{
-					"radarApiUrl":    "https://radar.test.com",
-					"instanceApiUrl": "https://instances.test.com",
+					"radarApiUrl": "https://radar.test.com",
+				},
+				Creds: map[string]any{
+					"org":    "org",
+					"token":  "token",
+					"region": "region",
+				},
+			},
+		},
+		{
+			name: "Case 1b: success with custom imdsUrl",
+			config: providers.Config{
+				Params: map[string]any{
+					"radarApiUrl": "https://radar.test.com",
+					"imdsUrl":     "http://custom-imds.example.com/meta_data.json",
 				},
 				Creds: map[string]any{
 					"org":    "org",
@@ -44,9 +76,7 @@ func TestLoader(t *testing.T) {
 		{
 			name: "Case 2: missing radarApiUrl",
 			config: providers.Config{
-				Params: map[string]any{
-					"instanceApiUrl": "https://instances.test.com",
-				},
+				Params: map[string]any{},
 				Creds: map[string]any{
 					"org":   "org",
 					"token": "token",
@@ -55,24 +85,10 @@ func TestLoader(t *testing.T) {
 			err: "missing 'radarApiUrl'",
 		},
 		{
-			name: "Case 3: missing instanceApiUrl",
+			name: "Case 3: missing org",
 			config: providers.Config{
 				Params: map[string]any{
 					"radarApiUrl": "https://radar.test.com",
-				},
-				Creds: map[string]any{
-					"org":   "org",
-					"token": "token",
-				},
-			},
-			err: "missing 'instanceApiUrl'",
-		},
-		{
-			name: "Case 4: missing org",
-			config: providers.Config{
-				Params: map[string]any{
-					"radarApiUrl":    "https://radar.test.com",
-					"instanceApiUrl": "https://instances.test.com",
 				},
 				Creds: map[string]any{
 					"token": "token",
@@ -81,17 +97,30 @@ func TestLoader(t *testing.T) {
 			err: "missing 'org'",
 		},
 		{
-			name: "Case 5: missing token",
+			name: "Case 4: missing token",
 			config: providers.Config{
 				Params: map[string]any{
-					"radarApiUrl":    "https://radar.test.com",
-					"instanceApiUrl": "https://instances.test.com",
+					"radarApiUrl": "https://radar.test.com",
 				},
 				Creds: map[string]any{
 					"org": "org",
 				},
 			},
 			err: "missing 'token'",
+		},
+		{
+			name: "Case 5: invalid imdsUrl type",
+			config: providers.Config{
+				Params: map[string]any{
+					"radarApiUrl": "https://radar.test.com",
+					"imdsUrl":     1,
+				},
+				Creds: map[string]any{
+					"org":   "org",
+					"token": "token",
+				},
+			},
+			err: "invalid 'imdsUrl' value '1': unsupported type int",
 		},
 	}
 
@@ -112,319 +141,476 @@ func TestLoader(t *testing.T) {
 	}
 }
 
-const placementsResponse = `[
-  {"metadata": {"id": "placement-1"}},
-  {"metadata": {"id": "placement-2"}}
-]`
-
-const placementServersResponseTmpl = `[
-  {
-    "metadata": {
-      "id": "%s",
-      "name": "%s",
-      "organizationId": "9a8c6370-4065-4d4a-9da0-7678df40cd9d",
-      "projectId": "e36c058a-8eba-4f5b-91f4-f6ffb983795c",
-      "creationTime": "2026-04-28T11:04:00Z",
-      "createdBy": "john.doe@example.com",
-      "provisioningStatus": "provisioned",
-      "healthStatus": "healthy"
-    },
-    "status": {
-      "regionId": "c7568e2d-f9ab-453d-9a3a-51375f78426b",
-      "reservationId": "a64f9269-36e0-4312-b8d1-52d93d569b7b",
-      "placementId": "%s",
-      "networkId": "61f0ad85-3001-41cb-824a-e6a047668dfe",
-      "powerState": "Running",
-      "privateIP": "10.0.0.12",
-      "macAddress": "fa:16:3e:7c:11:8a"
-    }
-  }
-]`
-
-func newTestProvider(t *testing.T, ctx context.Context, serverURL string) *Provider {
-	t.Helper()
-	provider, httpErr := Loader(ctx, providers.Config{
-		Params: map[string]any{
-			"radarApiUrl":    "https://radar.test.com",
-			"instanceApiUrl": serverURL,
-		},
-		Creds: map[string]any{
-			"org":    "org",
-			"token":  "token",
-			"region": "region",
-		},
+func TestGetParamsIMDSUrl(t *testing.T) {
+	p, err := getParams(map[string]any{
+		"radarApiUrl": "https://radar.test.com",
+		"imdsUrl":     "http://custom-imds.example.com/meta_data.json",
 	})
-	require.Nil(t, httpErr)
-	return provider.(*Provider)
-}
-
-func TestInstances2NodeMap(t *testing.T) {
-	ctx := context.Background()
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodGet, r.Method)
-		require.Equal(t, "Bearer token", r.Header.Get("Authorization"))
-
-		w.Header().Set("Content-Type", "application/json")
-
-		switch r.URL.Path {
-		case "/api/v2/placements":
-			require.Equal(t, "org", r.URL.Query().Get("organizationID"))
-			require.Equal(t, "region", r.URL.Query().Get("regionID"))
-			_, err := w.Write([]byte(placementsResponse))
-			require.NoError(t, err)
-		case "/api/v2/placements/placement-1/servers":
-			_, err := fmt.Fprintf(w, placementServersResponseTmpl, "psrv-7f3d9d5d2a7c4e32", "training-workers-0", "placement-1")
-			require.NoError(t, err)
-		case "/api/v2/placements/placement-2/servers":
-			_, err := fmt.Fprintf(w, placementServersResponseTmpl, "psrv-950ab3259a1443da", "training-workers-1", "placement-2")
-			require.NoError(t, err)
-		default:
-			t.Fatalf("unexpected request path %q", r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	p := newTestProvider(t, ctx, server.URL)
-
-	i2n, err := p.Instances2NodeMap(ctx, []string{"training-workers-0", "training-workers-1"})
 	require.NoError(t, err)
-	require.Equal(t, map[string]string{
-		"psrv-7f3d9d5d2a7c4e32": "training-workers-0",
-		"psrv-950ab3259a1443da": "training-workers-1",
-	}, i2n)
+	require.Equal(t, "http://custom-imds.example.com/meta_data.json", p.IMDSUrl)
 
-	i2n, err = p.Instances2NodeMap(ctx, nil)
+	p, err = getParams(map[string]any{
+		"radarApiUrl": "https://radar.test.com",
+	})
 	require.NoError(t, err)
-	require.Equal(t, map[string]string{
-		"psrv-7f3d9d5d2a7c4e32": "training-workers-0",
-		"psrv-950ab3259a1443da": "training-workers-1",
-	}, i2n)
+	require.Empty(t, p.IMDSUrl)
 }
 
-const placementServersMissingFieldsResponse = `[
-  {"metadata": {"id": "psrv-1", "name": "training-workers-0"}},
-  {"metadata": {"id": "", "name": "training-workers-1"}},
-  {"metadata": {"id": "psrv-2", "name": ""}},
-  {"metadata": {"id": "psrv-3", "name": "training-workers-2"}}
-]`
-
-func TestPlacementServers(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("excludes servers missing id or name", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, err := w.Write([]byte(placementServersMissingFieldsResponse))
-			require.NoError(t, err)
-		}))
-		defer server.Close()
-
-		c := &nscaleClient{instanceAPIURL: server.URL, token: "token"}
-		i2n, err := c.PlacementServers(ctx, "placement-1")
-		require.NoError(t, err)
-		require.Equal(t, map[string]string{
-			"psrv-1": "training-workers-0",
-			"psrv-3": "training-workers-2",
-		}, i2n)
-	})
-
-	t.Run("malformed JSON returns an error", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, err := w.Write([]byte(`{not valid json`))
-			require.NoError(t, err)
-		}))
-		defer server.Close()
-
-		c := &nscaleClient{instanceAPIURL: server.URL, token: "token"}
-		i2n, err := c.PlacementServers(ctx, "placement-1")
-		require.Error(t, err)
-		require.Nil(t, i2n)
-	})
-
-	t.Run("canceled context returns promptly without retries", func(t *testing.T) {
-		var requests int32
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			atomic.AddInt32(&requests, 1)
-			w.Header().Set("Content-Type", "application/json")
-			_, err := w.Write([]byte(placementsResponse))
-			require.NoError(t, err)
-		}))
-		defer server.Close()
-
-		cancelCtx, cancel := context.WithCancel(ctx)
-		cancel()
-
-		c := &nscaleClient{instanceAPIURL: server.URL, token: "token"}
-
-		start := time.Now()
-		i2n, err := c.PlacementServers(cancelCtx, "placement-1")
-		elapsed := time.Since(start)
-
-		require.Error(t, err)
-		require.Nil(t, i2n)
-		require.Less(t, elapsed, time.Second, "canceled context should fail immediately, not retry with backoff")
-		require.Equal(t, int32(0), atomic.LoadInt32(&requests), "canceled context should not reach the server")
-	})
-}
-
-const placementsResponseWithEmptyID = `[
-  {"metadata": {"id": "placement-1"}},
-  {"metadata": {"id": ""}},
-  {"metadata": {"id": "placement-2"}}
-]`
-
-func TestListPlacements(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("excludes placements missing id", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, err := w.Write([]byte(placementsResponseWithEmptyID))
-			require.NoError(t, err)
-		}))
-		defer server.Close()
-
-		c := &nscaleClient{instanceAPIURL: server.URL, token: "token"}
-		ids, err := c.ListPlacements(ctx, "org", "region")
-		require.NoError(t, err)
-		require.Equal(t, []string{"placement-1", "placement-2"}, ids)
-	})
-
-	t.Run("empty list returns no ids and no error", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, err := w.Write([]byte(`[]`))
-			require.NoError(t, err)
-		}))
-		defer server.Close()
-
-		c := &nscaleClient{instanceAPIURL: server.URL, token: "token"}
-		ids, err := c.ListPlacements(ctx, "org", "region")
-		require.NoError(t, err)
-		require.Empty(t, ids)
-	})
-
-	t.Run("malformed JSON returns HTTP 502", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, err := w.Write([]byte(`{not valid json`))
-			require.NoError(t, err)
-		}))
-		defer server.Close()
-
-		c := &nscaleClient{instanceAPIURL: server.URL, token: "token"}
-		ids, err := c.ListPlacements(ctx, "org", "region")
-		require.Error(t, err)
-		require.Nil(t, ids)
-
-		var httpErr *httperr.Error
-		require.ErrorAs(t, err, &httpErr)
-		require.Equal(t, http.StatusBadGateway, httpErr.Code())
-	})
-
-	t.Run("canceled context returns without issuing a request", func(t *testing.T) {
-		var requests int32
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			atomic.AddInt32(&requests, 1)
-			w.Header().Set("Content-Type", "application/json")
-			_, err := w.Write([]byte(placementsResponse))
-			require.NoError(t, err)
-		}))
-		defer server.Close()
-
-		cancelCtx, cancel := context.WithCancel(ctx)
-		cancel()
-
-		c := &nscaleClient{instanceAPIURL: server.URL, token: "token"}
-
-		start := time.Now()
-		ids, err := c.ListPlacements(cancelCtx, "org", "region")
-		elapsed := time.Since(start)
-
-		require.Error(t, err)
-		require.Nil(t, ids)
-		require.Less(t, elapsed, time.Second, "canceled context should fail immediately, not retry with backoff")
-		require.Equal(t, int32(0), atomic.LoadInt32(&requests), "canceled context should not reach the server")
-	})
-}
-
-func TestInstances2NodeMapErrors(t *testing.T) {
-	ctx := context.Background()
-
+func TestIMDSURL(t *testing.T) {
 	tests := []struct {
-		name             string
-		failPlacements   bool
-		statusCode       int
-		body             string
-		wantErrSubstring string
+		name     string
+		params   *ProviderParams
+		expected string
 	}{
 		{
-			name:             "400 invalid request listing placements",
-			failPlacements:   true,
-			statusCode:       http.StatusBadRequest,
-			body:             `{"error":"invalid_request","error_description":"request body invalid","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
-			wantErrSubstring: "failed to list placements",
+			name:     "Case 1: unset falls back to default",
+			params:   &ProviderParams{},
+			expected: IMDSURL,
 		},
 		{
-			name:             "401 authentication failed listing placements",
-			failPlacements:   true,
-			statusCode:       http.StatusUnauthorized,
-			body:             `{"error":"access_denied","error_description":"authentication failed","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
-			wantErrSubstring: "failed to list placements",
-		},
-		{
-			name:             "404 not found listing placements",
-			failPlacements:   true,
-			statusCode:       http.StatusNotFound,
-			body:             `{"error":"not_found","error_description":"the requested resource does not exist","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
-			wantErrSubstring: "failed to list placements",
-		},
-		{
-			name:             "403 forbidden fetching placement servers",
-			statusCode:       http.StatusForbidden,
-			body:             `{"error":"forbidden","error_description":"user credentials do not have the required privileges","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
-			wantErrSubstring: "failed to get placement servers",
-		},
-		{
-			name:             "500 server error fetching placement servers",
-			statusCode:       http.StatusInternalServerError,
-			body:             `{"error":"server_error","error_description":"failed to token claim","trace_id":"57bc14d9bd461f0b5a72db830149b67a"}`,
-			wantErrSubstring: "failed to get placement servers",
+			name:     "Case 2: custom URL overrides default",
+			params:   &ProviderParams{IMDSUrl: "http://custom-imds.example.com/meta_data.json"},
+			expected: "http://custom-imds.example.com/meta_data.json",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-
-				if r.URL.Path == "/api/v2/placements" {
-					if tt.failPlacements {
-						w.WriteHeader(tt.statusCode)
-						_, err := w.Write([]byte(tt.body))
-						require.NoError(t, err)
-						return
-					}
-					_, err := w.Write([]byte(placementsResponse))
-					require.NoError(t, err)
-					return
-				}
-
-				w.WriteHeader(tt.statusCode)
-				_, err := w.Write([]byte(tt.body))
-				require.NoError(t, err)
-			}))
-			defer server.Close()
-
-			p := newTestProvider(t, ctx, server.URL)
-			_, err := p.Instances2NodeMap(ctx, nil)
-			require.ErrorContains(t, err, tt.wantErrSubstring)
-
-			var httpErr *httperr.Error
-			require.ErrorAs(t, err, &httpErr)
-			require.Equal(t, tt.statusCode, httpErr.Code())
+			p := &baseProvider{params: tt.params}
+			require.Equal(t, tt.expected, p.imdsURL())
 		})
 	}
+}
+
+func TestFetchIMDSMetadataNilParams(t *testing.T) {
+	var gotURL string
+	p := &baseProvider{
+		imdsFetch: func(_ context.Context, _ []string, imdsURL string) (map[string]*imdsMetadata, error) {
+			gotURL = imdsURL
+			return fakeMetadata(), nil
+		},
+	}
+
+	data, err := p.fetchIMDSMetadata(context.Background(), []string{"node-1"})
+	require.NoError(t, err)
+	require.Equal(t, fakeMetadata(), data)
+	require.Equal(t, IMDSURL, gotURL)
+}
+
+func TestGenerateTopologyConfig(t *testing.T) {
+	blockID := "block-1"
+
+	tests := []struct {
+		name      string
+		client    Client
+		instances []topology.ComputeInstances
+		trimTiers int
+		err       string
+	}{
+		{
+			name: "Case 1: success",
+			client: &fakeClient{instances: []InstanceTopology{
+				{ServerID: "srv-1", NetworkPath: []string{"core-1", "spine-1", "leaf-1"}},
+				{ServerID: "srv-2", NetworkPath: []string{"core-1", "spine-1", "leaf-2"}, BlockID: &blockID},
+			}},
+			instances: []topology.ComputeInstances{
+				{
+					Region:    "region-a",
+					Instances: map[string]string{"srv-1": "node1", "srv-2": "node2"},
+				},
+			},
+		},
+		{
+			name:      "Case 2: no compute instances",
+			client:    &fakeClient{},
+			instances: nil,
+		},
+		{
+			name:   "Case 3: missing region",
+			client: &fakeClient{},
+			instances: []topology.ComputeInstances{
+				{Instances: map[string]string{"srv-1": "node1"}},
+			},
+			err: "must specify region",
+		},
+		{
+			name:   "Case 4: Radar API error",
+			client: &fakeClient{err: httperr.NewError(http.StatusBadGateway, "boom")},
+			instances: []topology.ComputeInstances{
+				{
+					Region:    "region-a",
+					Instances: map[string]string{"srv-1": "node1"},
+				},
+			},
+			err: "boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &baseProvider{
+				client: tt.client,
+				params: &ProviderParams{TrimTiers: tt.trimTiers},
+			}
+
+			graph, err := p.GenerateTopologyConfig(context.Background(), nil, tt.instances)
+
+			if len(tt.err) != 0 {
+				require.Nil(t, graph)
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), tt.err)
+			} else {
+				require.Nil(t, err)
+				require.NotNil(t, graph)
+
+				if tt.name == "Case 1: success" {
+					leaves := make(map[string]string)
+					collectLeafVertices(graph.Tiers, leaves)
+					require.Equal(t, map[string]string{"srv-1": "node1", "srv-2": "node2"}, leaves)
+
+					fc := tt.client.(*fakeClient)
+					require.NotEmpty(t, fc.regions)
+					for _, r := range fc.regions {
+						require.Equal(t, "region-a", r)
+					}
+				}
+			}
+		})
+	}
+}
+
+// collectLeafVertices walks the graph tree, collecting compute-node vertices
+// (those without children) into leaves, keyed by instance ID.
+func collectLeafVertices(v *topology.Vertex, leaves map[string]string) {
+	if v == nil {
+		return
+	}
+	if len(v.Vertices) == 0 {
+		if len(v.ID) != 0 {
+			leaves[v.ID] = v.Name
+		}
+		return
+	}
+	for _, child := range v.Vertices {
+		collectLeafVertices(child, leaves)
+	}
+}
+
+func TestNscaleClientTopology(t *testing.T) {
+	blockID := "block-1"
+
+	tests := []struct {
+		name     string
+		region   string
+		pageSize int
+		offset   int
+		status   int
+		body     string
+		expected []InstanceTopology
+		err      string
+	}{
+		{
+			name:     "Case 1: success",
+			region:   "region-a",
+			pageSize: 50,
+			offset:   100,
+			status:   http.StatusOK,
+			body: `{"results": [
+				{"server_id": "srv-1", "network_node_path": ["core-1", "spine-1", "leaf-1"]},
+				{"server_id": "srv-2", "network_node_path": ["core-1", "spine-1", "leaf-2"], "block_id": "block-1"}
+			]}`,
+			expected: []InstanceTopology{
+				{ServerID: "srv-1", NetworkPath: []string{"core-1", "spine-1", "leaf-1"}},
+				{ServerID: "srv-2", NetworkPath: []string{"core-1", "spine-1", "leaf-2"}, BlockID: &blockID},
+			},
+		},
+		{
+			name:     "Case 2: empty page",
+			region:   "region-a",
+			pageSize: 50,
+			offset:   0,
+			status:   http.StatusOK,
+			body:     `{"results": []}`,
+			expected: []InstanceTopology{},
+		},
+		{
+			name:     "Case 3: API error",
+			region:   "region-a",
+			pageSize: 50,
+			offset:   0,
+			status:   http.StatusBadRequest,
+			body:     `invalid request`,
+			err:      "invalid request",
+		},
+		{
+			name:     "Case 4: malformed JSON",
+			region:   "region-a",
+			pageSize: 50,
+			offset:   0,
+			status:   http.StatusOK,
+			body:     `not valid json`,
+			err:      "invalid character",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotMethod, gotPath, gotAuth, gotOrg, gotRegion string
+			var gotLimit, gotOffset string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotPath = r.URL.Path
+				gotAuth = r.Header.Get("Authorization")
+				gotOrg = r.Header.Get("X-Organization")
+				gotRegion = r.Header.Get("X-Region")
+				gotLimit = r.URL.Query().Get("limit")
+				gotOffset = r.URL.Query().Get("offset")
+
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(server.Close)
+
+			c := &nscaleClient{radarAPIURL: server.URL, org: "org1", token: "token1"}
+			resp, err := c.Topology(context.Background(), tt.region, tt.pageSize, tt.offset)
+
+			if len(tt.err) != 0 {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.err)
+			} else {
+				require.Nil(t, err)
+				require.Equal(t, tt.expected, resp)
+			}
+
+			require.Equal(t, http.MethodGet, gotMethod)
+			require.Equal(t, urlTopologyPath, gotPath)
+			require.Equal(t, "Bearer token1", gotAuth)
+			require.Equal(t, "org1", gotOrg)
+			require.Equal(t, tt.region, gotRegion)
+			require.Equal(t, strconv.Itoa(tt.pageSize), gotLimit)
+			require.Equal(t, strconv.Itoa(tt.offset), gotOffset)
+		})
+	}
+}
+
+func TestNscaleClientTopologyCanceledContext(t *testing.T) {
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-unblock
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results": []}`))
+	}))
+	t.Cleanup(func() {
+		close(unblock)
+		server.Close()
+	})
+
+	c := &nscaleClient{radarAPIURL: server.URL, org: "org1", token: "token1"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.Topology(ctx, "region-a", 50, 0)
+		done <- err
+	}()
+
+	<-started
+	cancel()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Topology did not return after context cancellation")
+	}
+}
+
+func fakeMetadata() map[string]*imdsMetadata {
+	return map[string]*imdsMetadata{
+		"node-1": {Meta: map[string]string{"serverID": "srv-1"}},
+	}
+}
+
+func TestFetchIMDSMetadataCachesRepeatedIdenticalNodes(t *testing.T) {
+	var calls int32
+	p := &baseProvider{
+		params: &ProviderParams{},
+		imdsFetch: func(_ context.Context, _ []string, _ string) (map[string]*imdsMetadata, error) {
+			atomic.AddInt32(&calls, 1)
+			return fakeMetadata(), nil
+		},
+	}
+	nodes := []string{"node-1"}
+
+	data1, err := p.fetchIMDSMetadata(context.Background(), nodes)
+	require.NoError(t, err)
+	data2, err := p.fetchIMDSMetadata(context.Background(), nodes)
+	require.NoError(t, err)
+
+	require.Equal(t, data1, data2)
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+
+	_, err = p.fetchIMDSMetadata(context.Background(), []string{"node-2"})
+	require.NoError(t, err)
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+func TestFetchIMDSMetadataConcurrentIdenticalNodesDedup(t *testing.T) {
+	var calls int32
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+
+	p := &baseProvider{
+		params: &ProviderParams{},
+		imdsFetch: func(_ context.Context, _ []string, _ string) (map[string]*imdsMetadata, error) {
+			atomic.AddInt32(&calls, 1)
+			close(started)
+			<-unblock
+			return fakeMetadata(), nil
+		},
+	}
+	nodes := []string{"node-1"}
+
+	type result struct {
+		data map[string]*imdsMetadata
+		err  error
+	}
+	results := make(chan result, 2)
+
+	go func() {
+		data, err := p.fetchIMDSMetadata(context.Background(), nodes)
+		results <- result{data, err}
+	}()
+
+	<-started // owner is in-flight, holding no lock, blocked on unblock
+
+	go func() {
+		data, err := p.fetchIMDSMetadata(context.Background(), nodes)
+		results <- result{data, err}
+	}()
+
+	close(unblock)
+
+	for i := 0; i < 2; i++ {
+		select {
+		case r := <-results:
+			require.NoError(t, r.err)
+			require.Equal(t, fakeMetadata(), r.data)
+		case <-time.After(5 * time.Second):
+			t.Fatal("fetchIMDSMetadata did not return")
+		}
+	}
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+func TestFetchIMDSMetadataWaiterCanceledContext(t *testing.T) {
+	var calls int32
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+
+	p := &baseProvider{
+		params: &ProviderParams{},
+		imdsFetch: func(_ context.Context, _ []string, _ string) (map[string]*imdsMetadata, error) {
+			atomic.AddInt32(&calls, 1)
+			close(started)
+			<-unblock
+			return fakeMetadata(), nil
+		},
+	}
+	nodes := []string{"node-1"}
+
+	ownerDone := make(chan struct{})
+	go func() {
+		_, _ = p.fetchIMDSMetadata(context.Background(), nodes)
+		close(ownerDone)
+	}()
+
+	<-started // owner is in-flight, blocked on unblock
+
+	waiterCtx, cancel := context.WithCancel(context.Background())
+	waiterErrCh := make(chan error, 1)
+	go func() {
+		_, err := p.fetchIMDSMetadata(waiterCtx, nodes)
+		waiterErrCh <- err
+	}()
+
+	cancel()
+
+	select {
+	case err := <-waiterErrCh:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("waiter did not return promptly after ctx cancellation")
+	}
+
+	// The canceled waiter must not have disturbed the owner's in-flight load.
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+
+	close(unblock)
+	select {
+	case <-ownerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("owner fetch did not complete")
+	}
+
+	data, err := p.fetchIMDSMetadata(context.Background(), nodes)
+	require.NoError(t, err)
+	require.Equal(t, fakeMetadata(), data)
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+func TestFetchIMDSMetadataFailureClearsInFlight(t *testing.T) {
+	var calls int32
+	wantErr := errors.New("pdsh failed")
+
+	p := &baseProvider{
+		params: &ProviderParams{},
+		imdsFetch: func(_ context.Context, _ []string, _ string) (map[string]*imdsMetadata, error) {
+			if atomic.AddInt32(&calls, 1) == 1 {
+				return nil, wantErr
+			}
+			return fakeMetadata(), nil
+		},
+	}
+	nodes := []string{"node-1"}
+
+	_, err := p.fetchIMDSMetadata(context.Background(), nodes)
+	require.ErrorIs(t, err, wantErr)
+	require.Nil(t, p.imdsInFlight)
+	require.Nil(t, p.imdsData)
+
+	data, err := p.fetchIMDSMetadata(context.Background(), nodes)
+	require.NoError(t, err)
+	require.Equal(t, fakeMetadata(), data)
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+func TestProviderInstanceAndRegionMapsFilterByRegion(t *testing.T) {
+	p := &Provider{
+		baseProvider: baseProvider{
+			params: &ProviderParams{},
+			creds:  &Credentials{Region: "region-a"},
+			imdsFetch: func(_ context.Context, _ []string, _ string) (map[string]*imdsMetadata, error) {
+				return map[string]*imdsMetadata{
+					"node-1": {Meta: map[string]string{"serverID": "srv-1", "regionID": "region-a"}},
+					"node-2": {Meta: map[string]string{"serverID": "srv-2", "regionID": "region-b"}},
+				}, nil
+			},
+		},
+	}
+	nodes := []string{"node-1", "node-2"}
+
+	i2n, err := p.Instances2NodeMap(context.Background(), nodes)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"srv-1": "node-1"}, i2n)
+
+	nodeRegions, err := p.GetInstancesRegions(context.Background(), nodes)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"node-1": "region-a"}, nodeRegions)
 }

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -126,3 +126,20 @@ func GetTrimTiers(params map[string]any) (int, error) {
 
 	return trimTiers, nil
 }
+
+// GetIMDSURL returns the optional provider-level override for the Instance
+// Metadata Service URL. It returns an empty string when unset, leaving the
+// caller to fall back to its provider-specific default.
+func GetIMDSURL(params map[string]any) (string, error) {
+	v, ok := params[topology.KeyIMDSURL]
+	if !ok || v == nil {
+		return "", nil
+	}
+
+	url, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("invalid '%s' value '%v': unsupported type %T", topology.KeyIMDSURL, v, v)
+	}
+
+	return url, nil
+}

--- a/pkg/providers/providers_test.go
+++ b/pkg/providers/providers_test.go
@@ -213,3 +213,50 @@ func TestGetTrimTiers(t *testing.T) {
 		})
 	}
 }
+
+func TestGetIMDSURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   map[string]any
+		expected string
+		err      string
+	}{
+		{
+			name:   "Case 1: missing key",
+			params: map[string]any{},
+		},
+		{
+			name: "Case 2: nil value",
+			params: map[string]any{
+				topology.KeyIMDSURL: nil,
+			},
+		},
+		{
+			name: "Case 3: string value",
+			params: map[string]any{
+				topology.KeyIMDSURL: "http://custom-imds.example.com/meta_data.json",
+			},
+			expected: "http://custom-imds.example.com/meta_data.json",
+		},
+		{
+			name: "Case 4: unsupported type",
+			params: map[string]any{
+				topology.KeyIMDSURL: 1,
+			},
+			err: "invalid 'imdsUrl' value '1': unsupported type int",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetIMDSURL(tt.params)
+
+			if len(tt.err) != 0 {
+				require.EqualError(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -25,6 +25,7 @@ const (
 	KeyNodeNameRegexp    = "nodeNameRegexp"
 	KeyFormat            = "format"
 	KeyTrimTiers         = "trimTiers"
+	KeyIMDSURL           = "imdsUrl"
 
 	KeyPlugin     = "plugin"
 	TopologyTree  = "topology/tree"


### PR DESCRIPTION
## Description
Updates the nscale provider to use the `list-placement-servers` end point instead of the `instances` api.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
