### PR TITLE
fix(translate): reject empty block size inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Block topology generation now rejects an empty accelerator-domain set instead of leaking the internal `-1` minimum-size sentinel as `BlockSizes=-1` when automatic block-size inference is enabled.
 - AWS provider authentication now uses the standard SDK credential chain when explicit credentials are absent, enabling EKS Pod Identity and IRSA with automatic temporary-credential refresh instead of forcing EC2 instance-role credentials.
 - Blank or whitespace-only `KUBE_QPS` and `KUBE_BURST` values are now treated as unset for non-Helm deployments, while numeric values may include surrounding whitespace.
 - Invalid `KUBE_QPS` and `KUBE_BURST` deployment values now fail Kubernetes-client provider and engine loading immediately with HTTP 400 instead of being retried as HTTP 502 errors.

--- a/pkg/providers/dra/provider_test.go
+++ b/pkg/providers/dra/provider_test.go
@@ -92,6 +92,34 @@ func TestGenerateTopologyConfigUsesAnnotatedInstanceID(t *testing.T) {
 	require.Equal(t, expectedDomains, graph.Domains)
 }
 
+func TestGenerateTopologyConfigRejectsMissingDomainLabels(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "k8s-node-1",
+		Annotations: map[string]string{
+			topology.KeyNodeInstance: "instance-123",
+			topology.KeyNodeRegion:   "local",
+		},
+	}}
+	provider := &Provider{
+		client:           fake.NewSimpleClientset(node),
+		accelerator:      mustAcceleratorDiscoverer(t, defaultDomainLabel),
+		acceleratorLabel: defaultDomainLabel,
+	}
+	instances := []topology.ComputeInstances{{
+		Region: "local",
+		Instances: map[string]string{
+			"instance-123": "scheduler-node-1",
+		},
+	}}
+
+	graph, httpErr := provider.GenerateTopologyConfig(context.Background(), nil, instances)
+
+	require.Nil(t, graph)
+	require.NotNil(t, httpErr)
+	require.Equal(t, 502, httpErr.Code())
+	require.ErrorContains(t, httpErr, `no matching nodes found; check label "nvidia.com/gpu.clique"`)
+}
+
 func mustAcceleratorDiscoverer(t *testing.T, labelKey string) accelerator.Discoverer {
 	t.Helper()
 	discoverer, err := accelerator.NewKubernetesDiscoverer(accelerator.KubernetesLabelSection(labelKey))

--- a/pkg/translate/block.go
+++ b/pkg/translate/block.go
@@ -16,15 +16,18 @@ import (
 	"github.com/NVIDIA/topograph/internal/httperr"
 )
 
-func findMinDomainSize(blocks []*blockInfo) int {
-	minDomainSize := -1
-	for _, block := range blocks {
+func findMinDomainSize(blocks []*blockInfo) (int, error) {
+	if len(blocks) == 0 {
+		return 0, fmt.Errorf("cannot determine blockSizes: topology contains no blocks")
+	}
+	minDomainSize := len(blocks[0].nodes)
+	for _, block := range blocks[1:] {
 		blocklen := len(block.nodes)
-		if minDomainSize == -1 || minDomainSize > blocklen {
+		if minDomainSize > blocklen {
 			minDomainSize = blocklen
 		}
 	}
-	return minDomainSize
+	return minDomainSize, nil
 }
 
 // getBlockSizes returns the BlockSizes list for Slurm's block topology.
@@ -33,12 +36,15 @@ func findMinDomainSize(blocks []*blockInfo) int {
 // count and k = floor(log2(N)) for N blocks: the base size matches the
 // smallest accelerator domain and each successive level doubles, up to the
 // largest power-of-two multiple that fits the block count.
-func getBlockSizes(blocks []*blockInfo, requestedBlockSizes []int) []int {
+func getBlockSizes(blocks []*blockInfo, requestedBlockSizes []int) ([]int, error) {
 	if len(requestedBlockSizes) != 0 {
-		return requestedBlockSizes
+		return requestedBlockSizes, nil
 	}
 	// get smallest domain size
-	minDomainSize := findMinDomainSize(blocks)
+	minDomainSize, err := findMinDomainSize(blocks)
+	if err != nil {
+		return nil, err
+	}
 	outputbs := []int{minDomainSize}
 	maxnumbs := int(math.Log2(float64(len(blocks))))
 
@@ -47,7 +53,7 @@ func getBlockSizes(blocks []*blockInfo, requestedBlockSizes []int) []int {
 		outputbs = append(outputbs, levelblocksize)
 	}
 
-	return outputbs
+	return outputbs, nil
 }
 
 func (nt *NetworkTopology) toBlockTopology(wr io.Writer, skeletonOnly bool) *httperr.Error {
@@ -71,7 +77,10 @@ func (nt *NetworkTopology) toBlockTopology(wr io.Writer, skeletonOnly bool) *htt
 		}
 	}
 	blocks = namedBlocks
-	blockSizes := getBlockSizes(blocks, effectiveBlockSizes)
+	blockSizes, err := getBlockSizes(blocks, effectiveBlockSizes)
+	if err != nil {
+		return httperr.NewError(http.StatusBadRequest, err.Error())
+	}
 
 	for _, bInfo := range blocks {
 		var comment string

--- a/pkg/translate/block_test.go
+++ b/pkg/translate/block_test.go
@@ -106,6 +106,13 @@ BlockName=b2 Nodes=n3
 BlockSizes=1,2
 `,
 		},
+		{
+			name: "Case 5: no blocks",
+			nt: &NetworkTopology{
+				config: &Config{},
+			},
+			err: "cannot determine blockSizes: topology contains no blocks",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -197,10 +204,34 @@ func TestGetBlockSizes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			blockSize := getBlockSizes(populateBlockInfo(tc.blocks), tc.blockSize)
+			blockSize, err := getBlockSizes(populateBlockInfo(tc.blocks), tc.blockSize)
+			require.NoError(t, err)
 			require.Equal(t, tc.expectedOutput, blockSize)
 		})
 	}
+
+	blockSizes, err := getBlockSizes(nil, nil)
+	require.EqualError(t, err, "cannot determine blockSizes: topology contains no blocks")
+	require.Nil(t, blockSizes)
+
+	requestedBlockSizes := []int{8, 16}
+	blockSizes, err = getBlockSizes(nil, requestedBlockSizes)
+	require.NoError(t, err)
+	require.Equal(t, requestedBlockSizes, blockSizes)
+}
+
+func TestFindMinDomainSize(t *testing.T) {
+	minDomainSize, err := findMinDomainSize(nil)
+	require.EqualError(t, err, "cannot determine blockSizes: topology contains no blocks")
+	require.Zero(t, minDomainSize)
+
+	minDomainSize, err = findMinDomainSize([]*blockInfo{
+		{nodes: []string{"node-1", "node-2", "node-3"}},
+		{nodes: []string{"node-4"}},
+		{nodes: []string{"node-5", "node-6"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, minDomainSize)
 }
 
 // TestGenerateTopologyConfig exercises GenerateTopologyConfig directly for a

--- a/pkg/translate/topology.go
+++ b/pkg/translate/topology.go
@@ -162,6 +162,9 @@ func (cfg *Config) Validate(graph *topology.Graph) error {
 				if graph == nil || graph.Domains == nil {
 					return fmt.Errorf("missing block topology for topology %q", topo)
 				}
+				if len(graph.Domains) == 0 {
+					return fmt.Errorf("block topology for topology %q contains no accelerator domains", topo)
+				}
 			case topology.TopologyFlat:
 				// nop
 			default:
@@ -180,6 +183,9 @@ func (cfg *Config) Validate(graph *topology.Graph) error {
 		case topology.TopologyBlock:
 			if graph == nil || graph.Domains == nil {
 				return fmt.Errorf("missing block topology")
+			}
+			if len(graph.Domains) == 0 {
+				return fmt.Errorf("block topology contains no accelerator domains")
 			}
 		default:
 			return fmt.Errorf("unsupported topology plugin %q", cfg.Plugin)

--- a/pkg/translate/topology_test.go
+++ b/pkg/translate/topology_test.go
@@ -94,7 +94,10 @@ SwitchName=switch.1.2 Nodes=node-2
 
 func TestValidateConfig(t *testing.T) {
 	emptyRoot := &topology.Graph{}
-	blockRoot := &topology.Graph{Domains: topology.NewDomainMap()}
+	emptyBlockRoot := &topology.Graph{Domains: topology.NewDomainMap()}
+	domains := topology.NewDomainMap()
+	domains.AddHost("domain-1", "instance-1", "node-1")
+	blockRoot := &topology.Graph{Domains: domains}
 
 	testCases := []struct {
 		name string
@@ -130,6 +133,14 @@ func TestValidateConfig(t *testing.T) {
 				Plugin: topology.TopologyBlock,
 			},
 			err: "missing block topology",
+		},
+		{
+			name: "Case 3.2: empty block root",
+			root: emptyBlockRoot,
+			cfg: &Config{
+				Plugin: topology.TopologyBlock,
+			},
+			err: "block topology contains no accelerator domains",
 		},
 		{
 			name: "Case 4: mutually exclusive parameters",
@@ -174,6 +185,19 @@ func TestValidateConfig(t *testing.T) {
 					"topo": {Plugin: topology.TopologyBlock}},
 			},
 			err: `missing block topology for topology "topo"`,
+		},
+		{
+			name: "Case 7.2: empty block root in topology spec",
+			root: emptyBlockRoot,
+			cfg: &Config{
+				Topologies: map[string]*TopologySpec{
+					"topo": {
+						Plugin: topology.TopologyBlock,
+						Nodes:  []string{"node-1"},
+					},
+				},
+			},
+			err: `block topology for topology "topo" contains no accelerator domains`,
 		},
 		{
 			name: "Case 8: missing nodes in topology spec",

--- a/pkg/translate/yaml.go
+++ b/pkg/translate/yaml.go
@@ -215,8 +215,12 @@ func (nt *NetworkTopology) getBlockTopologyUnit(topoName string, topoSpec *Topol
 			}
 		}
 
+		blockSizes, err := getBlockSizes(bInfos, effectiveBlockSizes)
+		if err != nil {
+			return nil, err
+		}
 		tu.Block = &BlockTopo{
-			BlockSizes: getBlockSizes(bInfos, effectiveBlockSizes),
+			BlockSizes: blockSizes,
 			Blocks:     blocks,
 			parents:    parents,
 		}

--- a/pkg/translate/yaml_test.go
+++ b/pkg/translate/yaml_test.go
@@ -411,7 +411,9 @@ func TestGetBlockTopologyUnitComplementEmptyNodes(t *testing.T) {
 // error — not an OOM kill — for both the block and tree topology plugins.
 func TestExpandDoSNodeRange(t *testing.T) {
 	t.Run(topology.TopologyBlock, func(t *testing.T) {
-		graph := &topology.Graph{Domains: topology.NewDomainMap()}
+		domains := topology.NewDomainMap()
+		domains.AddHost("domain-1", "instance-1", "node-1")
+		graph := &topology.Graph{Domains: domains}
 		cfg := &Config{
 			Topologies: map[string]*TopologySpec{
 				"evil": {


### PR DESCRIPTION
Prevent empty block topologies from emitting BlockSizes=-1 while preserving explicitly configured block sizes.

closes #468 