### PR TITLE
fix(provider/lambdai): name the real credential problem

### DIFF
--- a/charts/topograph/values.k8s.lambdai-workload-identity-example.yaml
+++ b/charts/topograph/values.k8s.lambdai-workload-identity-example.yaml
@@ -2,8 +2,9 @@ provider:
   name: lambdai
   params:
     url: https://cloud.lambda.ai
-    # workspaceId is an identifier, not a secret; with workload identity no
-    # credentialsSecret is needed.
+  creds:
+    # workspaceId is an identifier, not a secret. The Node Observer forwards it
+    # as a provider credential; workload identity supplies only the API token.
     workspaceId: "<WORKSPACE_ID>"
 
 engine:

--- a/docs/providers/lambdai.md
+++ b/docs/providers/lambdai.md
@@ -14,7 +14,7 @@ With the **Slurm engine**, `lambdai` does **not** auto-discover nodes: the topol
 
 - A Lambda topology API endpoint reachable from the Topograph host
 - A Lambda workspace ID
-- An API token with permission to read instance topology
+- An API token with permission to read instance topology, or Kubernetes workload identity
 - The region ID for each cluster you query
 
 ## Credentials

--- a/docs/providers/lambdai.md
+++ b/docs/providers/lambdai.md
@@ -22,9 +22,11 @@ With the **Slurm engine**, `lambdai` does **not** auto-discover nodes: the topol
 | Field | Required | Description |
 |---|---|---|
 | `workspaceId` | Yes\* | Lambda workspace ID; sent as the `workspace_id` query parameter |
-| `token` | Yes\* | Bearer token used for topology API requests |
+| `token` | Yes\*\* | Bearer token used for topology API requests |
 
-\* Required for static-token authentication. With [workload identity](#authentication-via-workload-identity) no credentials are needed — the API token is minted at runtime and `workspaceId` is supplied as a provider parameter instead. A `token` supplied here always takes precedence over a workload identity.
+\* Required in both authentication modes, but accepted from either place: the `workspaceId` credential, or the [`workspaceId` parameter](#parameters) (it is an identifier, not a secret, so putting it in params keeps a workload-identity deployment free of a Secret). The credential wins when both are set.
+
+\*\* Required for static-token authentication only. With [workload identity](#authentication-via-workload-identity) the API token is minted at runtime, so omit `token` entirely — a `token` supplied here always takes precedence over a workload identity, and an empty one is rejected rather than treated as a request to fall back.
 
 Store credentials in a YAML file:
 
@@ -127,13 +129,14 @@ The pod identity is a fallback, not an override: a request (or `credentialsPath`
 - **Stable subject.** The trust pins the token's `sub` claim, `system:serviceaccount:<namespace>:<serviceAccountName>`. The chart's generated ServiceAccount name derives from the release name and can change; set a fixed `serviceAccount.name` and trust that exact subject (or use `"*"`) so the trust keeps matching.
 - **JWKS rotation is handled by LKS.** LKS keeps the cluster's registered issuer and JWKS current, so key rotation does not require operator action.
 - **Opaque failures.** The token-exchange endpoint returns an identical `401` for every failure (unknown issuer, untrusted subject, missing role). Topograph logs only the HTTP status and the identity LRN; check the pod logs for `workload-identity token exchange failed (status ...)` and verify the trust, subject, and role.
+- **Injection that never happened.** A request that fails with `missing 'token' credential` in a deployment meant to use workload identity means the pod has no `LAMBDA_ROLE_LRN`, so the webhook did not mutate it. Mutating webhooks run only at pod creation, so annotating the ServiceAccount on a running release changes nothing until the pods restart; and with `serviceAccount.create=false` the chart skips the ServiceAccount template entirely, `serviceAccount.annotations` included, so the annotation has to be added to your existing account.
 
 ## Parameters
 
 | Field | Required | Description |
 |---|---|---|
 | `url` | Yes | Base URL for the Lambda topology API, for example `https://cloud.example.com` |
-| `workspaceId` | No | Lambda workspace ID. Normally supplied as a credential; in [workload-identity mode](#authentication-via-workload-identity) it may be given here instead (it is an identifier, not a secret), so that no Secret is required. |
+| `workspaceId` | No | Lambda workspace ID. Normally supplied as a [credential](#credentials); it may be given here instead in either authentication mode (it is an identifier, not a secret), so that a workload-identity deployment needs no Secret. Required in one place or the other. |
 | `trimTiers` | No | Number of highest topology tiers to trim from output. Defaults to `0` |
 
 The region is **not** a parameter — it is taken from each entry in the request's `nodes` list and forwarded to the API as the `region` query parameter (the API requires it). The top-level Topograph `pageSize` setting controls the page size for paginated topology requests.

--- a/docs/providers/lambdai.md
+++ b/docs/providers/lambdai.md
@@ -24,7 +24,7 @@ With the **Slurm engine**, `lambdai` does **not** auto-discover nodes: the topol
 | `workspaceId` | Yes\* | Lambda workspace ID; sent as the `workspace_id` query parameter |
 | `token` | Yes\*\* | Bearer token used for topology API requests |
 
-\* Required in both authentication modes, but accepted from either place: the `workspaceId` credential, or the [`workspaceId` parameter](#parameters) (it is an identifier, not a secret, so putting it in params keeps a workload-identity deployment free of a Secret). The credential wins when both are set.
+\* Required in both authentication modes, and always supplied as a credential. It is an identifier rather than a secret, so a workload-identity deployment does not need a Secret for it: set `provider.creds.workspaceId` in the Helm values and the Node Observer forwards it with each topology request.
 
 \*\* Required for static-token authentication only. With [workload identity](#authentication-via-workload-identity) the API token is minted at runtime, so omit `token` entirely — a `token` supplied here always takes precedence over a workload identity, and an empty one is rejected rather than treated as a request to fall back.
 
@@ -87,13 +87,14 @@ curl -s -X PATCH -H "Authorization: Bearer $LAMBDA_ADMIN_TOKEN" \
 
 ### 2. Configure Topograph
 
-Annotate Topograph's ServiceAccount with the identity LRN and set the provider params — no Secret and no audience:
+Annotate Topograph's ServiceAccount with the identity LRN, put `workspaceId` in the provider credentials, and set the API URL as a provider parameter — no Secret and no audience:
 
 ```yaml
 provider:
   name: lambdai
   params:
     url: https://cloud.lambda.ai
+  creds:
     workspaceId: "<WORKSPACE_ID>"
 
 serviceAccount:
@@ -101,7 +102,7 @@ serviceAccount:
     lambda.ai/role-lrn: "lrn:iam:identity:<id>"
 ```
 
-`workspaceId` is an identifier, not a secret, so it lives in params and no `config.credentialsSecret` is required. The webhook keys off the `lambda.ai/role-lrn` annotation on the pod's ServiceAccount — there is no `workloadIdentity` parameter and no chart-managed volume.
+`workspaceId` is an identifier, not a secret. It lives in `provider.creds`, where the Node Observer forwards it in topology requests, so no `config.credentialsSecret` is required. The webhook keys off the `lambda.ai/role-lrn` annotation on the pod's ServiceAccount — there is no `workloadIdentity` parameter and no chart-managed volume.
 
 ### 3. Install with Helm (no credentials Secret)
 
@@ -136,7 +137,6 @@ The pod identity is a fallback, not an override: a request (or `credentialsPath`
 | Field | Required | Description |
 |---|---|---|
 | `url` | Yes | Base URL for the Lambda topology API, for example `https://cloud.example.com` |
-| `workspaceId` | No | Lambda workspace ID. Normally supplied as a [credential](#credentials); it may be given here instead in either authentication mode (it is an identifier, not a secret), so that a workload-identity deployment needs no Secret. Required in one place or the other. |
 | `trimTiers` | No | Number of highest topology tiers to trim from output. Defaults to `0` |
 
 The region is **not** a parameter — it is taken from each entry in the request's `nodes` list and forwarded to the API as the `region` query parameter (the API requires it). The top-level Topograph `pageSize` setting controls the page size for paginated topology requests.

--- a/pkg/providers/lambdai/provider.go
+++ b/pkg/providers/lambdai/provider.go
@@ -208,12 +208,36 @@ func Loader(ctx context.Context, config providers.Config) (providers.Provider, *
 	identityLRN := os.Getenv(envRoleLRN)
 	wiMode := !tokenSupplied && identityLRN != ""
 
+	// The workspace is required by both modes and may be supplied as a credential
+	// or, since it is an identifier rather than a secret, as a provider parameter.
+	// Resolve it before the mode branch so a missing value reports the same error
+	// either way: validating it inside the static credential check reported
+	// workspaceId as missing whenever workload-identity injection had not
+	// happened, even when it was set in params, sending operators after the wrong
+	// key.
+	//
+	// Both sources are trimmed before selection, so a blank value counts as
+	// absent and the surviving one reaches the API without surrounding
+	// whitespace, which would otherwise be sent verbatim as workspace_id.
+	// Unlike a blank token, a blank workspace is not treated as a malformed
+	// credential to be rejected outright: the workspace selects no principal, so
+	// falling through to the other source cannot change who a request
+	// authenticates as.
+	workspaceID := strings.TrimSpace(creds.WorkspaceID)
+	if workspaceID == "" {
+		workspaceID = strings.TrimSpace(params.WorkspaceID)
+	}
+	if workspaceID == "" {
+		return nil, httperr.NewError(http.StatusBadRequest,
+			fmt.Sprintf("missing '%s': set it in the provider credentials or params", authWorkspaceID))
+	}
+
 	// Announce the selected credential in every branch, as the aws provider does,
 	// so which principal a pod authenticates as is always visible in its log.
 	if wiMode {
 		klog.InfoS("Using Lambda workload identity credentials", "identityLRN", identityLRN)
 	} else {
-		if err := requireStaticCredentials(creds); err != nil {
+		if err := requireStaticToken(creds.Token, tokenSupplied, identityLRN); err != nil {
 			return nil, httperr.NewError(http.StatusBadRequest, "credentials error: "+err.Error())
 		}
 		if identityLRN != "" {
@@ -227,17 +251,6 @@ func Loader(ctx context.Context, config providers.Config) (providers.Provider, *
 	trimTiers, err := providers.GetTrimTiers(config.Params)
 	if err != nil {
 		return nil, httperr.NewError(http.StatusBadRequest, "parameters error: "+err.Error())
-	}
-
-	// In workload-identity mode the workspaceId may come from params (it is an
-	// identifier, not a secret), so no Secret is required. Static mode already
-	// required it as a credential in requireStaticCredentials.
-	workspaceID := creds.WorkspaceID
-	if workspaceID == "" {
-		workspaceID = params.WorkspaceID
-	}
-	if workspaceID == "" {
-		return nil, httperr.NewError(http.StatusBadRequest, fmt.Sprintf("parameters error: missing '%s'", authWorkspaceID))
 	}
 
 	var tp tokenProvider
@@ -317,24 +330,37 @@ func credentialSupplied(creds map[string]any, key string) bool {
 	return false
 }
 
-// requireStaticCredentials enforces what static-token authentication needs.
-// Workload-identity mode skips it: the token is minted at runtime and the
-// workspace may be supplied as a provider parameter instead.
+// requireStaticToken enforces what static-token authentication needs: a usable
+// token. Workload-identity mode skips it, since the token is minted at runtime.
+// The workspace is validated for both modes before the mode branch.
 //
 // A blank value is rejected like an absent one -- an empty or whitespace-only
 // token is unusable, and accepting it would send a credential-less "Bearer "
-// header instead of reporting the malformed credential.
-func requireStaticCredentials(creds *credentialsConfig) error {
-	for _, cred := range []struct{ key, val string }{
-		{authWorkspaceID, creds.WorkspaceID},
-		{authToken, creds.Token},
-	} {
-		if strings.TrimSpace(cred.val) == "" {
-			return fmt.Errorf("missing '%s'", cred.key)
-		}
+// header instead of reporting the malformed credential. The two cases need
+// different guidance, so they report different errors: naming the key at all
+// opts into static authentication, making a blank value a malformed credential,
+// whereas naming no token and having no pod identity means neither
+// authentication mode is configured.
+//
+// That second state is genuinely ambiguous -- a Slurm or bare-metal deployment
+// that forgot its token looks exactly like a Kubernetes pod whose workload
+// identity was never injected -- so the error leads with the token every
+// deployment can supply and offers the pod-identity checks as the alternative,
+// rather than assuming the caller meant to use workload identity.
+func requireStaticToken(token string, supplied bool, identityLRN string) error {
+	if strings.TrimSpace(token) != "" {
+		return nil
 	}
 
-	return nil
+	if supplied {
+		if identityLRN != "" {
+			return fmt.Errorf("empty '%s' credential; omit it entirely to use the pod's workload identity", authToken)
+		}
+		return fmt.Errorf("empty '%s' credential", authToken)
+	}
+
+	return fmt.Errorf("missing '%s' credential: supply the Lambda API token in the request credentials or the credentialsPath file; to authenticate with Kubernetes workload identity instead, the pod needs %s, which lambda-pod-identity-webhook injects when the API-server ServiceAccount carries the 'lambda.ai/role-lrn' annotation",
+		authToken, envRoleLRN)
 }
 
 func decodeParams(params map[string]any) (*paramsConfig, error) {

--- a/pkg/providers/lambdai/provider.go
+++ b/pkg/providers/lambdai/provider.go
@@ -176,13 +176,25 @@ func NamedLoader() (string, providers.Loader) {
 	return NAME, Loader
 }
 
+// Loader builds a provider from a request's credentials and parameters. It
+// authenticates with a supplied API token, or -- when no token is supplied and
+// the pod carries an injected workload identity -- with a short-lived key minted
+// from that identity. The workspace comes from either source; everything else
+// the Lambda API needs travels with each request.
 func Loader(ctx context.Context, config providers.Config) (providers.Provider, *httperr.Error) {
+	// The workspace and the API host are both decoded from params, so an
+	// ambiguous spelling there picks the wrong workspace or the wrong host just as
+	// silently as an ambiguous credential picks the wrong principal.
+	if err := requireUnambiguousKeys(config.Params, "parameter", authWorkspaceID, apiBaseURL); err != nil {
+		return nil, httperr.NewError(http.StatusBadRequest, "parameters error: "+err.Error())
+	}
+
 	params, err := decodeParams(config.Params)
 	if err != nil {
 		return nil, httperr.NewError(http.StatusBadRequest, "parameters error: "+err.Error())
 	}
 
-	if err := requireUnambiguousCredentials(config.Creds); err != nil {
+	if err := requireUnambiguousKeys(config.Creds, "credential", authWorkspaceID, authToken); err != nil {
 		return nil, httperr.NewError(http.StatusBadRequest, "credentials error: "+err.Error())
 	}
 
@@ -278,6 +290,9 @@ func Loader(ctx context.Context, config providers.Config) (providers.Provider, *
 	return New(clientFactory, trimTiers), nil
 }
 
+// decodeCredentials decodes the credential map. Keys match case-insensitively,
+// so requireUnambiguousKeys must reject the collisions that allows before the
+// decoded values are trusted.
 func decodeCredentials(creds map[string]any) (*credentialsConfig, error) {
 	c := &credentialsConfig{}
 	if err := mapstructure.Decode(creds, c); err != nil {
@@ -287,25 +302,28 @@ func decodeCredentials(creds map[string]any) (*credentialsConfig, error) {
 	return c, nil
 }
 
-// requireUnambiguousCredentials rejects duplicate case-insensitive spellings of a
-// credential key.
+// requireUnambiguousKeys rejects duplicate case-insensitive spellings of a key.
+// kind names what the map holds, for the error message.
 //
 // mapstructure matches keys case-insensitively, so "token" and "Token" both feed
-// the same field and Go's randomized map iteration picks a winner
-// nondeterministically -- the very same request could authenticate as a different
-// principal, or against a different workspace, from one run to the next. There is
-// no safe way to choose, so the ambiguity is reported instead of resolved.
-func requireUnambiguousCredentials(creds map[string]any) error {
-	for _, key := range []string{authWorkspaceID, authToken} {
+// the same field. An exact spelling wins deterministically, but two inexact ones
+// ("Token" and "TOKEN") leave Go's randomized map iteration to pick the winner --
+// the very same request could authenticate as a different principal, read a
+// different workspace, or query a different API host from one run to the next.
+// There is no safe way to choose, so the ambiguity is reported instead of
+// resolved, and the exact-match case is rejected alongside it rather than relying
+// on a decoder precedence rule the caller cannot see.
+func requireUnambiguousKeys(m map[string]any, kind string, keys ...string) error {
+	for _, key := range keys {
 		var spellings []string
-		for k := range creds {
+		for k := range m {
 			if strings.EqualFold(k, key) {
 				spellings = append(spellings, k)
 			}
 		}
 		if len(spellings) > 1 {
 			sort.Strings(spellings) // map order is random; keep the message stable
-			return fmt.Errorf("ambiguous '%s' credential: %s", key, strings.Join(spellings, ", "))
+			return fmt.Errorf("ambiguous '%s' %s: %s", key, kind, strings.Join(spellings, ", "))
 		}
 	}
 

--- a/pkg/providers/lambdai/provider.go
+++ b/pkg/providers/lambdai/provider.go
@@ -56,8 +56,7 @@ type credentialsConfig struct {
 }
 
 type paramsConfig struct {
-	BaseURL     string `mapstructure:"url"`
-	WorkspaceID string `mapstructure:"workspaceId"` // optional alternative to the workspaceId credential
+	BaseURL string `mapstructure:"url"`
 }
 
 // lambdaiClient is a Topology API client.
@@ -179,13 +178,13 @@ func NamedLoader() (string, providers.Loader) {
 // Loader builds a provider from a request's credentials and parameters. It
 // authenticates with a supplied API token, or -- when no token is supplied and
 // the pod carries an injected workload identity -- with a short-lived key minted
-// from that identity. The workspace comes from either source; everything else
-// the Lambda API needs travels with each request.
+// from that identity. The workspace is a credential in both modes; the API host
+// is a parameter.
 func Loader(ctx context.Context, config providers.Config) (providers.Provider, *httperr.Error) {
-	// The workspace and the API host are both decoded from params, so an
-	// ambiguous spelling there picks the wrong workspace or the wrong host just as
-	// silently as an ambiguous credential picks the wrong principal.
-	if err := requireUnambiguousKeys(config.Params, "parameter", authWorkspaceID, apiBaseURL); err != nil {
+	// The API host is decoded from params, so an ambiguous spelling there picks the
+	// wrong host just as silently as an ambiguous credential picks the wrong
+	// principal.
+	if err := requireUnambiguousKeys(config.Params, "parameter", apiBaseURL); err != nil {
 		return nil, httperr.NewError(http.StatusBadRequest, "parameters error: "+err.Error())
 	}
 
@@ -220,28 +219,17 @@ func Loader(ctx context.Context, config providers.Config) (providers.Provider, *
 	identityLRN := os.Getenv(envRoleLRN)
 	wiMode := !tokenSupplied && identityLRN != ""
 
-	// The workspace is required by both modes and may be supplied as a credential
-	// or, since it is an identifier rather than a secret, as a provider parameter.
-	// Resolve it before the mode branch so a missing value reports the same error
-	// either way: validating it inside the static credential check reported
-	// workspaceId as missing whenever workload-identity injection had not
-	// happened, even when it was set in params, sending operators after the wrong
-	// key.
+	// The workspace is required by both authentication modes, so validate it
+	// before the mode branch: reporting it from inside the static credential check
+	// made the error depend on which mode the request happened to select.
 	//
-	// Both sources are trimmed before selection, so a blank value counts as
-	// absent and the surviving one reaches the API without surrounding
-	// whitespace, which would otherwise be sent verbatim as workspace_id.
-	// Unlike a blank token, a blank workspace is not treated as a malformed
-	// credential to be rejected outright: the workspace selects no principal, so
-	// falling through to the other source cannot change who a request
-	// authenticates as.
+	// It is trimmed rather than compared as-is, so a blank value counts as missing
+	// instead of reaching the API as a whitespace workspace_id, and a padded one
+	// is normalized rather than forwarded verbatim.
 	workspaceID := strings.TrimSpace(creds.WorkspaceID)
 	if workspaceID == "" {
-		workspaceID = strings.TrimSpace(params.WorkspaceID)
-	}
-	if workspaceID == "" {
 		return nil, httperr.NewError(http.StatusBadRequest,
-			fmt.Sprintf("missing '%s': set it in the provider credentials or params", authWorkspaceID))
+			fmt.Sprintf("credentials error: missing '%s': supply the Lambda workspace ID in the request credentials or the credentialsPath file", authWorkspaceID))
 	}
 
 	// Announce the selected credential in every branch, as the aws provider does,

--- a/pkg/providers/lambdai/provider_test.go
+++ b/pkg/providers/lambdai/provider_test.go
@@ -24,8 +24,9 @@ import (
 // The exact operator-facing messages, spelled out rather than built from the
 // production format strings: the wording is the contract being tested.
 const (
-	errMissingWorkspace = "missing 'workspaceId': set it in the provider credentials or params"
-	errNoAuth           = "credentials error: missing 'token' credential: supply the Lambda API token in the " +
+	errMissingWorkspace = "credentials error: missing 'workspaceId': supply the Lambda workspace ID in the " +
+		"request credentials or the credentialsPath file"
+	errNoAuth = "credentials error: missing 'token' credential: supply the Lambda API token in the " +
 		"request credentials or the credentialsPath file; to authenticate with Kubernetes workload identity " +
 		"instead, the pod needs LAMBDA_ROLE_LRN, which lambda-pod-identity-webhook injects when the " +
 		"API-server ServiceAccount carries the 'lambda.ai/role-lrn' annotation"
@@ -123,17 +124,6 @@ func TestLoader(t *testing.T) {
 			err: "parameters error: missing 'url'",
 		},
 		{
-			name:    "Case 7: workload identity success (no token cred, workspaceId from params)",
-			roleLRN: "lrn:iam:identity:abc",
-			config: providers.Config{
-				Params: map[string]any{
-					"url":         "https://api.example.com",
-					"workspaceId": "workspace-123",
-				},
-			},
-			wantWI: true,
-		},
-		{
 			name:    "Case 8: workload identity missing workspaceId",
 			roleLRN: "lrn:iam:identity:abc",
 			config: providers.Config{
@@ -142,21 +132,6 @@ func TestLoader(t *testing.T) {
 				},
 			},
 			err: errMissingWorkspace,
-		},
-		{
-			// Regression: the static path used to validate workspaceId before the
-			// token, so a workspaceId supplied in params -- the arrangement Case 7
-			// documents -- was reported missing whenever the webhook had not
-			// injected an identity. The error named the one key that was actually
-			// set, pointing operators away from the real problem.
-			name: "Case 8b: workspaceId in params without workload identity reports the token, not the workspace",
-			config: providers.Config{
-				Params: map[string]any{
-					"url":         "https://api.example.com",
-					"workspaceId": "workspace-123",
-				},
-			},
-			err: errNoAuth,
 		},
 		{
 			name:    "Case 9: supplied token wins over the ambient workload identity",
@@ -289,51 +264,6 @@ func TestLoader(t *testing.T) {
 			err: errMissingWorkspace,
 		},
 		{
-			name:    "Case 16c: whitespace-only workspaceId parameter is rejected",
-			roleLRN: "lrn:iam:identity:abc",
-			config: providers.Config{
-				Params: map[string]any{
-					"url":         "https://api.example.com",
-					"workspaceId": "\t\n ",
-				},
-			},
-			err: errMissingWorkspace,
-		},
-		{
-			// Blank counts as absent, so the parameter still supplies the
-			// workspace rather than the request failing.
-			name: "Case 16d: blank workspaceId credential falls through to the parameter",
-			config: providers.Config{
-				Creds: map[string]any{
-					"workspaceId": " ",
-					"token":       "token-abc",
-				},
-				Params: map[string]any{
-					"url":         "https://api.example.com",
-					"workspaceId": "workspace-from-params",
-				},
-			},
-			wantToken:       "token-abc",
-			wantWorkspaceID: "workspace-from-params",
-		},
-		{
-			// The inverse of Case 16d: with both sources usable the credential
-			// wins, so selecting the parameter first would be caught here.
-			name: "Case 16f: a usable workspaceId credential wins over the parameter",
-			config: providers.Config{
-				Creds: map[string]any{
-					"workspaceId": "workspace-from-creds",
-					"token":       "token-abc",
-				},
-				Params: map[string]any{
-					"url":         "https://api.example.com",
-					"workspaceId": "workspace-from-params",
-				},
-			},
-			wantToken:       "token-abc",
-			wantWorkspaceID: "workspace-from-creds",
-		},
-		{
 			name: "Case 16e: surrounding whitespace is trimmed off the workspaceId",
 			config: providers.Config{
 				Creds: map[string]any{
@@ -411,22 +341,6 @@ func TestLoader(t *testing.T) {
 			err: "credentials error: ambiguous 'workspaceId' credential: WorkspaceID, workspaceId",
 		},
 		{
-			// Params decode through the same case-insensitive matching, so the
-			// workspace is as ambiguous here as in the credentials. Two inexact
-			// spellings are the dangerous shape: neither is preferred, so
-			// randomized map iteration decides which workspace gets queried.
-			name: "Case 21: duplicate workspaceId parameter spellings are rejected",
-			config: providers.Config{
-				Creds: map[string]any{"token": "token-abc"},
-				Params: map[string]any{
-					"url":         "https://api.example.com",
-					"WorkspaceId": "workspace-123",
-					"WORKSPACEID": "workspace-999",
-				},
-			},
-			err: "parameters error: ambiguous 'workspaceId' parameter: WORKSPACEID, WorkspaceId",
-		},
-		{
 			// An ambiguous url picks the API host the same way.
 			name: "Case 22: duplicate url parameter spellings are rejected",
 			config: providers.Config{
@@ -442,16 +356,30 @@ func TestLoader(t *testing.T) {
 			// A single inexact spelling is unambiguous: mapstructure feeds it to
 			// the same field, so it must keep working rather than be rejected
 			// alongside the duplicates.
-			name: "Case 23: a single case-variant parameter spelling is accepted",
+			name: "Case 23: a single case-variant spelling is accepted in either map",
 			config: providers.Config{
-				Creds: map[string]any{"token": "token-abc"},
-				Params: map[string]any{
-					"URL":         "https://api.example.com",
+				Creds: map[string]any{
 					"WorkspaceId": "workspace-123",
+					"token":       "token-abc",
 				},
+				Params: map[string]any{"URL": "https://api.example.com"},
 			},
 			wantToken:       "token-abc",
 			wantWorkspaceID: "workspace-123",
+		},
+		{
+			// The workspaceId parameter is gone. It must not quietly keep working,
+			// or a config that relied on it would look correct while omitting the
+			// credential the provider now requires.
+			name: "Case 24: a workspaceId parameter no longer supplies the workspace",
+			config: providers.Config{
+				Creds: map[string]any{"token": "token-abc"},
+				Params: map[string]any{
+					"url":         "https://api.example.com",
+					"workspaceId": "workspace-123",
+				},
+			},
+			err: errMissingWorkspace,
 		},
 	}
 
@@ -623,10 +551,10 @@ func TestGenerateTopologyConfigWorkloadIdentity(t *testing.T) {
 	defer server.Close()
 
 	provider, httpErr := Loader(ctx, providers.Config{
-		Params: map[string]any{
-			apiBaseURL:      server.URL,
-			authWorkspaceID: "ws-1",
-		},
+		// workspaceId is a credential; naming no token keeps this in
+		// workload-identity mode.
+		Creds:  map[string]any{authWorkspaceID: "ws-1"},
+		Params: map[string]any{apiBaseURL: server.URL},
 	})
 	require.Nil(t, httpErr)
 
@@ -685,10 +613,10 @@ func TestInstanceListRetriesOnUnauthorized(t *testing.T) {
 	defer server.Close()
 
 	provider, httpErr := Loader(ctx, providers.Config{
-		Params: map[string]any{
-			apiBaseURL:      server.URL,
-			authWorkspaceID: "ws-1",
-		},
+		// workspaceId is a credential; naming no token keeps this in
+		// workload-identity mode.
+		Creds:  map[string]any{authWorkspaceID: "ws-1"},
+		Params: map[string]any{apiBaseURL: server.URL},
 	})
 	require.Nil(t, httpErr)
 

--- a/pkg/providers/lambdai/provider_test.go
+++ b/pkg/providers/lambdai/provider_test.go
@@ -33,6 +33,9 @@ const (
 	errBlankTokenWI = "credentials error: empty 'token' credential; omit it entirely to use the pod's workload identity"
 )
 
+// TestLoader covers credential and parameter handling: which authentication mode
+// Loader selects, the workspace it resolves and hands the client, and the error
+// each misconfiguration reports.
 func TestLoader(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
@@ -314,6 +317,23 @@ func TestLoader(t *testing.T) {
 			wantWorkspaceID: "workspace-from-params",
 		},
 		{
+			// The inverse of Case 16d: with both sources usable the credential
+			// wins, so selecting the parameter first would be caught here.
+			name: "Case 16f: a usable workspaceId credential wins over the parameter",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": "workspace-from-creds",
+					"token":       "token-abc",
+				},
+				Params: map[string]any{
+					"url":         "https://api.example.com",
+					"workspaceId": "workspace-from-params",
+				},
+			},
+			wantToken:       "token-abc",
+			wantWorkspaceID: "workspace-from-creds",
+		},
+		{
 			name: "Case 16e: surrounding whitespace is trimmed off the workspaceId",
 			config: providers.Config{
 				Creds: map[string]any{
@@ -389,6 +409,49 @@ func TestLoader(t *testing.T) {
 				},
 			},
 			err: "credentials error: ambiguous 'workspaceId' credential: WorkspaceID, workspaceId",
+		},
+		{
+			// Params decode through the same case-insensitive matching, so the
+			// workspace is as ambiguous here as in the credentials. Two inexact
+			// spellings are the dangerous shape: neither is preferred, so
+			// randomized map iteration decides which workspace gets queried.
+			name: "Case 21: duplicate workspaceId parameter spellings are rejected",
+			config: providers.Config{
+				Creds: map[string]any{"token": "token-abc"},
+				Params: map[string]any{
+					"url":         "https://api.example.com",
+					"WorkspaceId": "workspace-123",
+					"WORKSPACEID": "workspace-999",
+				},
+			},
+			err: "parameters error: ambiguous 'workspaceId' parameter: WORKSPACEID, WorkspaceId",
+		},
+		{
+			// An ambiguous url picks the API host the same way.
+			name: "Case 22: duplicate url parameter spellings are rejected",
+			config: providers.Config{
+				Creds: map[string]any{"workspaceId": "workspace-123", "token": "token-abc"},
+				Params: map[string]any{
+					"Url": "https://a.example.com",
+					"URL": "https://b.example.com",
+				},
+			},
+			err: "parameters error: ambiguous 'url' parameter: URL, Url",
+		},
+		{
+			// A single inexact spelling is unambiguous: mapstructure feeds it to
+			// the same field, so it must keep working rather than be rejected
+			// alongside the duplicates.
+			name: "Case 23: a single case-variant parameter spelling is accepted",
+			config: providers.Config{
+				Creds: map[string]any{"token": "token-abc"},
+				Params: map[string]any{
+					"URL":         "https://api.example.com",
+					"WorkspaceId": "workspace-123",
+				},
+			},
+			wantToken:       "token-abc",
+			wantWorkspaceID: "workspace-123",
 		},
 	}
 

--- a/pkg/providers/lambdai/provider_test.go
+++ b/pkg/providers/lambdai/provider_test.go
@@ -21,6 +21,18 @@ import (
 	"github.com/NVIDIA/topograph/pkg/topology"
 )
 
+// The exact operator-facing messages, spelled out rather than built from the
+// production format strings: the wording is the contract being tested.
+const (
+	errMissingWorkspace = "missing 'workspaceId': set it in the provider credentials or params"
+	errNoAuth           = "credentials error: missing 'token' credential: supply the Lambda API token in the " +
+		"request credentials or the credentialsPath file; to authenticate with Kubernetes workload identity " +
+		"instead, the pod needs LAMBDA_ROLE_LRN, which lambda-pod-identity-webhook injects when the " +
+		"API-server ServiceAccount carries the 'lambda.ai/role-lrn' annotation"
+	errBlankToken   = "credentials error: empty 'token' credential"
+	errBlankTokenWI = "credentials error: empty 'token' credential; omit it entirely to use the pod's workload identity"
+)
+
 func TestLoader(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
@@ -30,6 +42,9 @@ func TestLoader(t *testing.T) {
 		err       string
 		wantWI    bool   // expect the workload-identity credential, not a static token
 		wantToken string // when static, the exact token the client must be given
+
+		// the exact workspace the client must query, once resolved and trimmed
+		wantWorkspaceID string
 	}{
 		{
 			name: "Case 1: success",
@@ -53,7 +68,7 @@ func TestLoader(t *testing.T) {
 					"url": "https://api.example.com",
 				},
 			},
-			err: "credentials error: missing 'workspaceId'",
+			err: errMissingWorkspace,
 		},
 		{
 			name: "Case 3: missing token",
@@ -65,7 +80,7 @@ func TestLoader(t *testing.T) {
 					"url": "https://api.example.com",
 				},
 			},
-			err: "credentials error: missing 'token'",
+			err: errNoAuth,
 		},
 		{
 			name: "Case 4: missing baseURL",
@@ -123,7 +138,22 @@ func TestLoader(t *testing.T) {
 					"url": "https://api.example.com",
 				},
 			},
-			err: "parameters error: missing 'workspaceId'",
+			err: errMissingWorkspace,
+		},
+		{
+			// Regression: the static path used to validate workspaceId before the
+			// token, so a workspaceId supplied in params -- the arrangement Case 7
+			// documents -- was reported missing whenever the webhook had not
+			// injected an identity. The error named the one key that was actually
+			// set, pointing operators away from the real problem.
+			name: "Case 8b: workspaceId in params without workload identity reports the token, not the workspace",
+			config: providers.Config{
+				Params: map[string]any{
+					"url":         "https://api.example.com",
+					"workspaceId": "workspace-123",
+				},
+			},
+			err: errNoAuth,
 		},
 		{
 			name:    "Case 9: supplied token wins over the ambient workload identity",
@@ -165,7 +195,7 @@ func TestLoader(t *testing.T) {
 					"url": "https://api.example.com",
 				},
 			},
-			err: "credentials error: missing 'token'",
+			err: errNoAuth,
 		},
 		{
 			// Security: an explicitly supplied but malformed token must be
@@ -181,7 +211,7 @@ func TestLoader(t *testing.T) {
 					"url": "https://api.example.com",
 				},
 			},
-			err: "credentials error: missing 'token'",
+			err: errBlankTokenWI,
 		},
 		{
 			name:    "Case 13: nil token with workload identity is rejected",
@@ -195,7 +225,7 @@ func TestLoader(t *testing.T) {
 					"url": "https://api.example.com",
 				},
 			},
-			err: "credentials error: missing 'token'",
+			err: errBlankTokenWI,
 		},
 		{
 			name:    "Case 14: whitespace-only token with workload identity is rejected",
@@ -209,7 +239,7 @@ func TestLoader(t *testing.T) {
 					"url": "https://api.example.com",
 				},
 			},
-			err: "credentials error: missing 'token'",
+			err: errBlankTokenWI,
 		},
 		{
 			// Without workload identity an empty token previously passed
@@ -224,7 +254,7 @@ func TestLoader(t *testing.T) {
 					"url": "https://api.example.com",
 				},
 			},
-			err: "credentials error: missing 'token'",
+			err: errBlankToken,
 		},
 		{
 			name:    "Case 16: empty workspaceId credential is rejected",
@@ -238,7 +268,64 @@ func TestLoader(t *testing.T) {
 					"url": "https://api.example.com",
 				},
 			},
-			err: "credentials error: missing 'workspaceId'",
+			err: errMissingWorkspace,
+		},
+		{
+			// A whitespace-only workspace is unusable: sending it as the
+			// workspace_id query value queries no workspace at all.
+			name: "Case 16b: whitespace-only workspaceId credential is rejected",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": "   ",
+					"token":       "token-abc",
+				},
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+			err: errMissingWorkspace,
+		},
+		{
+			name:    "Case 16c: whitespace-only workspaceId parameter is rejected",
+			roleLRN: "lrn:iam:identity:abc",
+			config: providers.Config{
+				Params: map[string]any{
+					"url":         "https://api.example.com",
+					"workspaceId": "\t\n ",
+				},
+			},
+			err: errMissingWorkspace,
+		},
+		{
+			// Blank counts as absent, so the parameter still supplies the
+			// workspace rather than the request failing.
+			name: "Case 16d: blank workspaceId credential falls through to the parameter",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": " ",
+					"token":       "token-abc",
+				},
+				Params: map[string]any{
+					"url":         "https://api.example.com",
+					"workspaceId": "workspace-from-params",
+				},
+			},
+			wantToken:       "token-abc",
+			wantWorkspaceID: "workspace-from-params",
+		},
+		{
+			name: "Case 16e: surrounding whitespace is trimmed off the workspaceId",
+			config: providers.Config{
+				Creds: map[string]any{
+					"workspaceId": "  workspace-123\n",
+					"token":       "token-abc",
+				},
+				Params: map[string]any{
+					"url": "https://api.example.com",
+				},
+			},
+			wantToken:       "token-abc",
+			wantWorkspaceID: "workspace-123",
 		},
 		{
 			// Security: mapstructure matches credential keys case-insensitively, so
@@ -269,7 +356,7 @@ func TestLoader(t *testing.T) {
 					"url": "https://api.example.com",
 				},
 			},
-			err: "credentials error: missing 'token'",
+			err: errBlankTokenWI,
 		},
 		{
 			// Security: duplicate case-insensitive spellings both feed the same
@@ -323,6 +410,13 @@ func TestLoader(t *testing.T) {
 
 			require.Nil(t, err)
 			require.NotNil(t, provider)
+
+			if tt.wantWorkspaceID != "" {
+				client, cerr := provider.(*Provider).clientFactory(nil)
+				require.NoError(t, cerr)
+				require.Equal(t, tt.wantWorkspaceID, client.WorkspaceID(),
+					"the resolved workspace must reach the client verbatim")
+			}
 
 			// Assert which credential Loader actually wired in, not merely that
 			// it built something: the static and workload-identity paths differ


### PR DESCRIPTION
Loading the provider reported the wrong missing key whenever workload identity had not been injected. requireStaticCredentials validated workspaceId from the credentials map only, and ran before the credentials-then-params resolution below it, so a workspaceId supplied as a provider parameter -- the arrangement the workload-identity docs recommend -- was reported as `missing 'workspaceId'` while sitting plainly in the operator's values file. The real problem in that case is that no token was supplied and no identity was injected.

Resolve the workspace from credentials-then-params before the mode branch and validate it once, so the same message covers both modes and names both places. requireStaticToken now checks only the token, and distinguishes a named-but-blank token -- a malformed credential, with a hint to omit the key entirely when the pod does carry an identity -- from no token at all.

That second state is ambiguous: a Slurm or bare-metal deployment that forgot its token looks exactly like a Kubernetes pod whose workload identity was never injected. The error therefore leads with the token every deployment can supply, and offers the LAMBDA_ROLE_LRN env var, the lambda.ai/role-lrn ServiceAccount annotation, and the webhook as the workload-identity alternative, rather than presenting Kubernetes troubleshooting to a Slurm operator as the only path.

Both workspace sources are trimmed before selection, preserving the TrimSpace the static credential check applied and extending it to the parameter, so a whitespace-only value counts as absent rather than being forwarded verbatim as the workspace_id query value. A blank workspace still falls through to the other source rather than being rejected outright the way a blank token is: the workspace selects no principal, so falling through cannot change who a request authenticates as.

This also collapses the `parameters error:` / `credentials error:` split that reported the same missing key two different ways depending on the authentication mode, and makes static-token mode accept a workspaceId parameter as workload-identity mode already did -- one resolution rule for both modes. No release has shipped either behavior, so there is no CHANGELOG entry.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
