### PR TITLE
fix(provider/lambdai): follow the webhook's identity-lrn rename

### DIFF
--- a/charts/topograph/values.k8s.lambdai-workload-identity-example.yaml
+++ b/charts/topograph/values.k8s.lambdai-workload-identity-example.yaml
@@ -11,12 +11,12 @@ engine:
   name: k8s
 
 # lambda-pod-identity-webhook injects the projected ServiceAccount token and the
-# LAMBDA_ROLE_LRN / LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE env vars into the
+# LAMBDA_IDENTITY_LRN / LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE env vars into the
 # API-server pod because its ServiceAccount carries this annotation. No token
 # Secret, no audience, and no chart-managed volume are required.
 serviceAccount:
   annotations:
-    lambda.ai/role-lrn: "lrn:iam:identity:<id>"
+    lambda.ai/identity-lrn: "lrn:iam:identity:<id>"
 
 nodeObserver:
   topograph:

--- a/docs/providers/lambdai.md
+++ b/docs/providers/lambdai.md
@@ -52,7 +52,7 @@ The cluster's OIDC provider (issuer + JWKS) is **pre-registered by LKS** at prov
 ### Prerequisites
 
 - An **LKS cluster** — its OIDC issuer and public JWKS are registered with Lambda automatically at provisioning.
-- **`lambda-pod-identity-webhook`** installed in the cluster (LKS ships it). The webhook watches for pods whose ServiceAccount is annotated `lambda.ai/role-lrn` and mutates them to inject the projected token and identity env vars.
+- **`lambda-pod-identity-webhook`** installed in the cluster (LKS ships it). The webhook watches for pods whose ServiceAccount is annotated `lambda.ai/identity-lrn` and mutates them to inject the projected token and identity env vars.
 - **Workload identity enabled** for your Lambda account.
 - A Lambda **admin API key** for the one-time operator setup below.
 
@@ -99,10 +99,10 @@ provider:
 
 serviceAccount:
   annotations:
-    lambda.ai/role-lrn: "lrn:iam:identity:<id>"
+    lambda.ai/identity-lrn: "lrn:iam:identity:<id>"
 ```
 
-`workspaceId` is an identifier, not a secret. It lives in `provider.creds`, where the Node Observer forwards it in topology requests, so no `config.credentialsSecret` is required. The webhook keys off the `lambda.ai/role-lrn` annotation on the pod's ServiceAccount — there is no `workloadIdentity` parameter and no chart-managed volume.
+`workspaceId` is an identifier, not a secret. It lives in `provider.creds`, where the Node Observer forwards it in topology requests, so no `config.credentialsSecret` is required. The webhook keys off the `lambda.ai/identity-lrn` annotation on the pod's ServiceAccount — there is no `workloadIdentity` parameter and no chart-managed volume. ServiceAccounts annotated before that key was renamed still work: the webhook reads the older `lambda.ai/role-lrn` when the current key is absent, so migrating is not urgent, but annotate new accounts with `lambda.ai/identity-lrn`.
 
 ### 3. Install with Helm (no credentials Secret)
 
@@ -116,12 +116,12 @@ See [`values.k8s.lambdai-workload-identity-example.yaml`](../../charts/topograph
 
 ### How it works
 
-Because the pod's ServiceAccount carries the `lambda.ai/role-lrn` annotation, `lambda-pod-identity-webhook` mutates the pod to inject:
+Because the pod's ServiceAccount carries the `lambda.ai/identity-lrn` annotation, `lambda-pod-identity-webhook` mutates the pod to inject:
 
 - a projected ServiceAccount token at `/var/run/secrets/lambda.ai/serviceaccount/token`, and
-- the env vars `LAMBDA_ROLE_LRN` (the identity LRN) and `LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE` (the token path).
+- the env vars `LAMBDA_IDENTITY_LRN` (the identity LRN) and `LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE` (the token path). The webhook also injects the deprecated `LAMBDA_ROLE_LRN` with the same value while operators migrate; Topograph reads it only when `LAMBDA_IDENTITY_LRN` is absent.
 
-Topograph reads `LAMBDA_ROLE_LRN` to switch into workload-identity mode, reads the projected token from `LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE`, and exchanges it at `POST /api/v1/oidc/token` for a Lambda API key. The key is cached process-wide and refreshed shortly (≈5 minutes, jittered) before expiry so a fleet of pods does not refresh in lockstep. A transient exchange failure while the cached key is still valid is tolerated — Topograph keeps serving the current key until it actually expires. If the Lambda API rejects a cached key mid-life, Topograph mints a new one and retries the request once.
+Topograph reads `LAMBDA_IDENTITY_LRN` to switch into workload-identity mode, reads the projected token from `LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE`, and exchanges it at `POST /api/v1/oidc/token` for a Lambda API key. The key is cached process-wide and refreshed shortly (≈5 minutes, jittered) before expiry so a fleet of pods does not refresh in lockstep. A transient exchange failure while the cached key is still valid is tolerated — Topograph keeps serving the current key until it actually expires. If the Lambda API rejects a cached key mid-life, Topograph mints a new one and retries the request once.
 
 The pod identity is a fallback, not an override: a request (or `credentialsPath`) that supplies a `token` credential authenticates with **that** token even when the pod carries a workload identity, so a caller's credentials are never silently replaced by the pod's principal. Topograph logs which one it used. Supplying a `token` that is empty or whitespace is treated as a malformed credential and rejected with `400` — not as a request to fall back to the pod identity. To use workload identity, omit the `token` credential entirely.
 
@@ -130,7 +130,7 @@ The pod identity is a fallback, not an override: a request (or `credentialsPath`
 - **Stable subject.** The trust pins the token's `sub` claim, `system:serviceaccount:<namespace>:<serviceAccountName>`. The chart's generated ServiceAccount name derives from the release name and can change; set a fixed `serviceAccount.name` and trust that exact subject (or use `"*"`) so the trust keeps matching.
 - **JWKS rotation is handled by LKS.** LKS keeps the cluster's registered issuer and JWKS current, so key rotation does not require operator action.
 - **Opaque failures.** The token-exchange endpoint returns an identical `401` for every failure (unknown issuer, untrusted subject, missing role). Topograph logs only the HTTP status and the identity LRN; check the pod logs for `workload-identity token exchange failed (status ...)` and verify the trust, subject, and role.
-- **Injection that never happened.** A request that fails with `missing 'token' credential` in a deployment meant to use workload identity means the pod has no `LAMBDA_ROLE_LRN`, so the webhook did not mutate it. Mutating webhooks run only at pod creation, so annotating the ServiceAccount on a running release changes nothing until the pods restart; and with `serviceAccount.create=false` the chart skips the ServiceAccount template entirely, `serviceAccount.annotations` included, so the annotation has to be added to your existing account.
+- **Injection that never happened.** A request that fails with `missing 'token' credential` in a deployment meant to use workload identity means the pod has no `LAMBDA_IDENTITY_LRN`, so the webhook did not mutate it. Mutating webhooks run only at pod creation, so annotating the ServiceAccount on a running release changes nothing until the pods restart; and with `serviceAccount.create=false` the chart skips the ServiceAccount template entirely, `serviceAccount.annotations` included, so the annotation has to be added to your existing account.
 
 ## Parameters
 

--- a/pkg/providers/lambdai/provider.go
+++ b/pkg/providers/lambdai/provider.go
@@ -202,8 +202,8 @@ func Loader(ctx context.Context, config providers.Config) (providers.Provider, *
 		return nil, httperr.NewError(http.StatusBadRequest, "credentials error: "+err.Error())
 	}
 
-	// lambda-pod-identity-webhook injects LAMBDA_ROLE_LRN into pods whose
-	// ServiceAccount carries the lambda.ai/role-lrn annotation. That identity is
+	// lambda-pod-identity-webhook injects LAMBDA_IDENTITY_LRN into pods whose
+	// ServiceAccount carries the lambda.ai/identity-lrn annotation. That identity is
 	// ambient pod infrastructure, so a token supplied with the request takes
 	// precedence over it -- the same explicit-then-ambient tiering the aws
 	// provider applies. Without that precedence a pod running under workload
@@ -216,7 +216,7 @@ func Loader(ctx context.Context, config providers.Config) (providers.Provider, *
 	// identity instead of being rejected. Naming the key at all opts into static
 	// authentication, and a blank value is then a validation error.
 	tokenSupplied := credentialSupplied(config.Creds, authToken)
-	identityLRN := os.Getenv(envRoleLRN)
+	identityLRN := injectedIdentityLRN()
 	wiMode := !tokenSupplied && identityLRN != ""
 
 	// The workspace is required by both authentication modes, so validate it
@@ -365,8 +365,8 @@ func requireStaticToken(token string, supplied bool, identityLRN string) error {
 		return fmt.Errorf("empty '%s' credential", authToken)
 	}
 
-	return fmt.Errorf("missing '%s' credential: supply the Lambda API token in the request credentials or the credentialsPath file; to authenticate with Kubernetes workload identity instead, the pod needs %s, which lambda-pod-identity-webhook injects when the API-server ServiceAccount carries the 'lambda.ai/role-lrn' annotation",
-		authToken, envRoleLRN)
+	return fmt.Errorf("missing '%s' credential: supply the Lambda API token in the request credentials or the credentialsPath file; to authenticate with Kubernetes workload identity instead, the pod needs %s, which lambda-pod-identity-webhook injects when the API-server ServiceAccount carries the 'lambda.ai/identity-lrn' annotation",
+		authToken, envIdentityLRN)
 }
 
 func decodeParams(params map[string]any) (*paramsConfig, error) {

--- a/pkg/providers/lambdai/provider_test.go
+++ b/pkg/providers/lambdai/provider_test.go
@@ -28,8 +28,8 @@ const (
 		"request credentials or the credentialsPath file"
 	errNoAuth = "credentials error: missing 'token' credential: supply the Lambda API token in the " +
 		"request credentials or the credentialsPath file; to authenticate with Kubernetes workload identity " +
-		"instead, the pod needs LAMBDA_ROLE_LRN, which lambda-pod-identity-webhook injects when the " +
-		"API-server ServiceAccount carries the 'lambda.ai/role-lrn' annotation"
+		"instead, the pod needs LAMBDA_IDENTITY_LRN, which lambda-pod-identity-webhook injects when the " +
+		"API-server ServiceAccount carries the 'lambda.ai/identity-lrn' annotation"
 	errBlankToken   = "credentials error: empty 'token' credential"
 	errBlankTokenWI = "credentials error: empty 'token' credential; omit it entirely to use the pod's workload identity"
 )
@@ -40,12 +40,12 @@ const (
 func TestLoader(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
-		name      string
-		roleLRN   string // LAMBDA_ROLE_LRN; non-empty selects workload-identity mode
-		config    providers.Config
-		err       string
-		wantWI    bool   // expect the workload-identity credential, not a static token
-		wantToken string // when static, the exact token the client must be given
+		name        string
+		identityLRN string // LAMBDA_IDENTITY_LRN; non-empty selects workload-identity mode
+		config      providers.Config
+		err         string
+		wantWI      bool   // expect the workload-identity credential, not a static token
+		wantToken   string // when static, the exact token the client must be given
 
 		// the exact workspace the client must query, once resolved and trimmed
 		wantWorkspaceID string
@@ -124,8 +124,8 @@ func TestLoader(t *testing.T) {
 			err: "parameters error: missing 'url'",
 		},
 		{
-			name:    "Case 8: workload identity missing workspaceId",
-			roleLRN: "lrn:iam:identity:abc",
+			name:        "Case 8: workload identity missing workspaceId",
+			identityLRN: "lrn:iam:identity:abc",
 			config: providers.Config{
 				Params: map[string]any{
 					"url": "https://api.example.com",
@@ -134,8 +134,8 @@ func TestLoader(t *testing.T) {
 			err: errMissingWorkspace,
 		},
 		{
-			name:    "Case 9: supplied token wins over the ambient workload identity",
-			roleLRN: "lrn:iam:identity:abc",
+			name:        "Case 9: supplied token wins over the ambient workload identity",
+			identityLRN: "lrn:iam:identity:abc",
 			config: providers.Config{
 				Creds: map[string]any{
 					"workspaceId": "workspace-123",
@@ -149,8 +149,8 @@ func TestLoader(t *testing.T) {
 		{
 			// A workspaceId credential alone is not a token, so the ambient
 			// identity still applies rather than failing on the missing token.
-			name:    "Case 10: workspaceId cred with workload identity stays in WI mode",
-			roleLRN: "lrn:iam:identity:abc",
+			name:        "Case 10: workspaceId cred with workload identity stays in WI mode",
+			identityLRN: "lrn:iam:identity:abc",
 			config: providers.Config{
 				Creds: map[string]any{
 					"workspaceId": "workspace-123",
@@ -178,8 +178,8 @@ func TestLoader(t *testing.T) {
 		{
 			// Security: an explicitly supplied but malformed token must be
 			// rejected, never silently downgraded to the pod identity.
-			name:    "Case 12: empty token with workload identity is rejected",
-			roleLRN: "lrn:iam:identity:abc",
+			name:        "Case 12: empty token with workload identity is rejected",
+			identityLRN: "lrn:iam:identity:abc",
 			config: providers.Config{
 				Creds: map[string]any{
 					"workspaceId": "workspace-123",
@@ -192,8 +192,8 @@ func TestLoader(t *testing.T) {
 			err: errBlankTokenWI,
 		},
 		{
-			name:    "Case 13: nil token with workload identity is rejected",
-			roleLRN: "lrn:iam:identity:abc",
+			name:        "Case 13: nil token with workload identity is rejected",
+			identityLRN: "lrn:iam:identity:abc",
 			config: providers.Config{
 				Creds: map[string]any{
 					"workspaceId": "workspace-123",
@@ -206,8 +206,8 @@ func TestLoader(t *testing.T) {
 			err: errBlankTokenWI,
 		},
 		{
-			name:    "Case 14: whitespace-only token with workload identity is rejected",
-			roleLRN: "lrn:iam:identity:abc",
+			name:        "Case 14: whitespace-only token with workload identity is rejected",
+			identityLRN: "lrn:iam:identity:abc",
 			config: providers.Config{
 				Creds: map[string]any{
 					"workspaceId": "workspace-123",
@@ -235,8 +235,8 @@ func TestLoader(t *testing.T) {
 			err: errBlankToken,
 		},
 		{
-			name:    "Case 16: empty workspaceId credential is rejected",
-			roleLRN: "",
+			name:        "Case 16: empty workspaceId credential is rejected",
+			identityLRN: "",
 			config: providers.Config{
 				Creds: map[string]any{
 					"workspaceId": "",
@@ -281,8 +281,8 @@ func TestLoader(t *testing.T) {
 			// Security: mapstructure matches credential keys case-insensitively, so
 			// mode selection must too. A case variant that populates the token must
 			// not be treated as absent and downgraded to the pod identity.
-			name:    "Case 17: case-variant token with workload identity is still used",
-			roleLRN: "lrn:iam:identity:abc",
+			name:        "Case 17: case-variant token with workload identity is still used",
+			identityLRN: "lrn:iam:identity:abc",
 			config: providers.Config{
 				Creds: map[string]any{
 					"WorkspaceId": "workspace-123",
@@ -295,8 +295,8 @@ func TestLoader(t *testing.T) {
 			wantToken: "token-abc",
 		},
 		{
-			name:    "Case 18: blank case-variant token with workload identity is rejected",
-			roleLRN: "lrn:iam:identity:abc",
+			name:        "Case 18: blank case-variant token with workload identity is rejected",
+			identityLRN: "lrn:iam:identity:abc",
 			config: providers.Config{
 				Creds: map[string]any{
 					"workspaceId": "workspace-123",
@@ -312,8 +312,8 @@ func TestLoader(t *testing.T) {
 			// Security: duplicate case-insensitive spellings both feed the same
 			// decoded field, and randomized map iteration picks the winner, so the
 			// ambiguity is reported rather than resolved arbitrarily.
-			name:    "Case 19: duplicate token spellings are rejected",
-			roleLRN: "lrn:iam:identity:abc",
+			name:        "Case 19: duplicate token spellings are rejected",
+			identityLRN: "lrn:iam:identity:abc",
 			config: providers.Config{
 				Creds: map[string]any{
 					"workspaceId": "workspace-123",
@@ -385,9 +385,10 @@ func TestLoader(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Mode is selected by env, not params: static cases pin it empty so
-			// ambient env can't flip them into workload-identity mode.
-			t.Setenv(envRoleLRN, tt.roleLRN)
+			// Mode is selected by env, not params: static cases pin both names
+			// empty so ambient env can't flip them into workload-identity mode.
+			t.Setenv(envIdentityLRN, tt.identityLRN)
+			t.Setenv(envRoleLRN, "")
 			resetCredentialCache()
 			provider, err := Loader(ctx, tt.config)
 
@@ -445,7 +446,9 @@ func tokenProviderOf(t *testing.T, p providers.Provider) tokenProvider {
 // page_token pagination, and the networkPath -> leaf/spine/core mapping.
 func TestGenerateTopologyConfig(t *testing.T) {
 	ctx := context.Background()
-	t.Setenv(envRoleLRN, "") // static-token mode: no workload identity
+	// static-token mode: no workload identity under either env var
+	t.Setenv(envIdentityLRN, "")
+	t.Setenv(envRoleLRN, "")
 
 	const page1 = `{"data":[
 		{"id":"i-1","networkPath":[{"id":"leaf1"},{"id":"spine1"},{"id":"core1"}],"nvlink":null},
@@ -511,7 +514,7 @@ SwitchName=leaf2 Nodes=node3
 // TestGenerateTopologyConfigWorkloadIdentity drives the workload-identity path
 // end to end against a single mock server that answers both the OIDC
 // token-exchange and the topology endpoint. The webhook model is simulated by
-// setting the LAMBDA_ROLE_LRN and LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE env vars;
+// setting the LAMBDA_IDENTITY_LRN and LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE env vars;
 // the test asserts that the provider reads the projected ServiceAccount token,
 // exchanges it once, and uses the minted key as the Bearer credential on the
 // topology request. No token or workspaceId credential is supplied.
@@ -520,7 +523,8 @@ func TestGenerateTopologyConfigWorkloadIdentity(t *testing.T) {
 	resetCredentialCache()
 
 	saTokenPath := writeToken(t, "sa-jwt-value\n")
-	t.Setenv(envRoleLRN, "lrn:iam:identity:abc")
+	t.Setenv(envIdentityLRN, "lrn:iam:identity:abc")
+	t.Setenv(envRoleLRN, "")
 	t.Setenv(envTokenFile, saTokenPath)
 
 	const topoPage = `{"data":[
@@ -581,7 +585,8 @@ func TestInstanceListRetriesOnUnauthorized(t *testing.T) {
 	resetCredentialCache()
 
 	saTokenPath := writeToken(t, "sa-jwt-value")
-	t.Setenv(envRoleLRN, "lrn:iam:identity:abc")
+	t.Setenv(envIdentityLRN, "lrn:iam:identity:abc")
+	t.Setenv(envRoleLRN, "")
 	t.Setenv(envTokenFile, saTokenPath)
 
 	const topoPage = `{"data":[
@@ -643,7 +648,8 @@ func TestSuppliedTokenWinsOverWorkloadIdentity(t *testing.T) {
 	resetCredentialCache()
 
 	// A full workload-identity environment is present and must be ignored.
-	t.Setenv(envRoleLRN, "lrn:iam:identity:abc")
+	t.Setenv(envIdentityLRN, "lrn:iam:identity:abc")
+	t.Setenv(envRoleLRN, "")
 	t.Setenv(envTokenFile, writeToken(t, "sa-jwt-value"))
 
 	const topoPage = `{"data":[
@@ -777,6 +783,7 @@ func TestInstanceListStaleUnauthorizedKeepsRefreshedKey(t *testing.T) {
 // not re-minted or replayed -- only a workload-identity key is refreshable.
 func TestStaticTokenDoesNotRetryOnUnauthorized(t *testing.T) {
 	ctx := context.Background()
+	t.Setenv(envIdentityLRN, "")
 	t.Setenv(envRoleLRN, "")
 
 	var topoHits int
@@ -802,4 +809,52 @@ func TestStaticTokenDoesNotRetryOnUnauthorized(t *testing.T) {
 	})
 	require.NotNil(t, httpErr)
 	require.Equal(t, 1, topoHits, "a static token must not be replayed on 401")
+}
+
+// TestInjectedIdentityLRN covers the webhook rename: it injects
+// LAMBDA_IDENTITY_LRN and, for the transition, the deprecated LAMBDA_ROLE_LRN
+// alongside it. Reading the current name first keeps working once the webhook
+// stops setting the old one, while the fallback keeps pods admitted by an older
+// webhook authenticating.
+func TestInjectedIdentityLRN(t *testing.T) {
+	const (
+		current    = "lrn:iam:identity:c0000000000000000000000000000000"
+		deprecated = "lrn:iam:identity:d0000000000000000000000000000000"
+	)
+
+	tests := []struct {
+		name                 string
+		identityLRN, roleLRN string
+		want                 string
+	}{
+		{name: "current name only", identityLRN: current, want: current},
+		{name: "deprecated name only", roleLRN: deprecated, want: deprecated},
+		{name: "both: current wins", identityLRN: current, roleLRN: deprecated, want: current},
+		{name: "neither: no identity injected", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envIdentityLRN, tt.identityLRN)
+			t.Setenv(envRoleLRN, tt.roleLRN)
+
+			require.Equal(t, tt.want, injectedIdentityLRN())
+		})
+	}
+}
+
+// TestLoaderDeprecatedRoleLRNEnv pins the fallback end to end: a pod carrying
+// only the deprecated env var still selects workload-identity mode rather than
+// failing on the missing token.
+func TestLoaderDeprecatedRoleLRNEnv(t *testing.T) {
+	t.Setenv(envIdentityLRN, "")
+	t.Setenv(envRoleLRN, "lrn:iam:identity:abc")
+	resetCredentialCache()
+
+	provider, err := Loader(context.Background(), providers.Config{
+		Creds:  map[string]any{"workspaceId": "workspace-123"},
+		Params: map[string]any{"url": "https://api.example.com"},
+	})
+	require.Nil(t, err)
+	require.IsType(t, &workloadIdentityCredential{}, tokenProviderOf(t, provider))
 }

--- a/pkg/providers/lambdai/token.go
+++ b/pkg/providers/lambdai/token.go
@@ -25,9 +25,17 @@ import (
 
 const (
 	// Env vars injected by lambda-pod-identity-webhook into pods whose
-	// ServiceAccount carries the lambda.ai/role-lrn annotation.
-	envRoleLRN   = "LAMBDA_ROLE_LRN"
-	envTokenFile = "LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE"
+	// ServiceAccount carries the lambda.ai/identity-lrn annotation.
+	envIdentityLRN = "LAMBDA_IDENTITY_LRN"
+	envTokenFile   = "LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE"
+
+	// envRoleLRN is the webhook's previous name for envIdentityLRN. The webhook
+	// injects both while operators migrate their ServiceAccount annotations, so
+	// this is read only when the current name is absent.
+	//
+	// Deprecated: read envIdentityLRN; this exists so pods admitted by an older
+	// webhook keep authenticating.
+	envRoleLRN = "LAMBDA_ROLE_LRN"
 
 	// defaultSATokenPath matches where the webhook mounts the projected token;
 	// used only if envTokenFile is unset.
@@ -44,6 +52,17 @@ const (
 	// through its own retry cycle while a usable cached key is still in hand.
 	failedRefreshBackoff = 30 * time.Second
 )
+
+// injectedIdentityLRN returns the workload identity the webhook injected,
+// preferring the current env var over the deprecated one it still sets alongside
+// it. An empty result means no identity was injected at all.
+func injectedIdentityLRN() string {
+	if lrn := os.Getenv(envIdentityLRN); lrn != "" {
+		return lrn
+	}
+
+	return os.Getenv(envRoleLRN)
+}
 
 // tokenProvider yields a Lambda API bearer token. *httperr.Error preserves the
 // provider-boundary contract so the correct HTTP status propagates.


### PR DESCRIPTION
lambda-pod-identity-webhook renamed its ServiceAccount annotation to lambda.ai/identity-lrn and the injected env var to LAMBDA_IDENTITY_LRN (lambdal/lambda-pod-identity-webhook#3). Both previous names still work there for the transition: the old annotation is read when the new one is absent, and the old env var is injected alongside the new one.

Read LAMBDA_IDENTITY_LRN, falling back to LAMBDA_ROLE_LRN, mirroring the webhook's own precedence. Nothing breaks today, since the webhook still sets both, but the deprecated variable will eventually stop being injected and workload-identity mode would then silently downgrade to requiring a static token.

Rename the annotation in the docs, the workload-identity example values file, and the missing-token diagnostic, which named the old annotation and env var as the things to check. The docs note that ServiceAccounts annotated before the rename keep working, so no operator is forced to migrate on our account.

TestInjectedIdentityLRN covers the precedence directly and TestLoaderDeprecatedRoleLRNEnv covers it through Loader; the mode-selecting tests now pin both variables so an ambient value cannot flip a static case into workload-identity mode. No CHANGELOG entry: the workload-identity support these names belong to is still under [Unreleased], so neither name has shipped.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
