### PR TITLE
fix(providers): correct page size handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+### Fixed
+
+- GCP and OCI simulation providers now handle partial final pagination pages without indexing past the available instances.
+- Non-positive `pageSize` configuration values now emit a warning and use the provider default instead of reaching provider APIs and simulation pagination loops.
+
 ---
 
 ## [v1.0.0] - 2026-08-18

--- a/config/topograph-config.yaml
+++ b/config/topograph-config.yaml
@@ -10,7 +10,7 @@ http:
 # waiting period before processing a request
 requestAggregationDelay: 15s
 
-# number of results per API call (optional)
+# number of results per API call (optional); non-positive values use the provider default
 pageSize: 100
 
 # ssl credentials for when http.ssl = true

--- a/docs/api.md
+++ b/docs/api.md
@@ -30,6 +30,7 @@ engine: slurm
 requestAggregationDelay: 15s
 
 # pageSize: sets the page size for topology requests against a CSP API (optional).
+# Non-positive values emit a warning and use the provider default.
 pageSize: 100
 
 # ssl: specifies the paths to the TLS certificate, private key,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,6 +75,11 @@ func NewFromFile(fname string) (*Config, error) {
 }
 
 func (cfg *Config) validate() error {
+	if cfg.PageSize != nil && *cfg.PageSize <= 0 {
+		klog.Warningf("pageSize %d is invalid; using the provider default", *cfg.PageSize)
+		cfg.PageSize = nil
+	}
+
 	if cfg.HTTP.Port == 0 {
 		return fmt.Errorf("port is not set")
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -119,6 +119,33 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, "/etc/slurm/config.yaml", os.Getenv("SLURM_CONF"))
 	require.Equal(t, path, os.Getenv("PATH"))
 }
+
+func TestValidatePageSize(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pageSize *int
+		expected *int
+	}{
+		{name: "nil"},
+		{name: "negative", pageSize: ptr.Int(-1)},
+		{name: "zero", pageSize: ptr.Int(0)},
+		{name: "positive", pageSize: ptr.Int(50), expected: ptr.Int(50)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{
+				HTTP:                    Endpoint{Port: 49021},
+				RequestAggregationDelay: time.Second,
+				PageSize:                tc.pageSize,
+			}
+
+			require.NoError(t, cfg.validate())
+			require.Equal(t, tc.expected, cfg.PageSize)
+		})
+	}
+}
+
 func TestValidate(t *testing.T) {
 	cert, err := os.CreateTemp("", "test-cert-*.yml")
 	require.NoError(t, err)

--- a/pkg/providers/aws/instance_topology.go
+++ b/pkg/providers/aws/instance_topology.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"k8s.io/klog/v2"
@@ -60,8 +61,9 @@ func (p *baseProvider) generateRegionInstanceTopology(ctx context.Context, pageS
 			input.InstanceIds = append(input.InstanceIds, instanceID)
 		}
 	} else {
-		klog.Infof("Getting instance topology with page size %d", pageSize)
-		input.MaxResults = client.PageSize()
+		pageSz := client.PageSize()
+		klog.Infof("Getting instance topology with page size %d", aws.ToInt32(pageSz))
+		input.MaxResults = pageSz
 	}
 
 	var cycle, total int

--- a/pkg/providers/gcp/provider_sim.go
+++ b/pkg/providers/gcp/provider_sim.go
@@ -74,7 +74,7 @@ func (c *simClient) Instances(ctx context.Context, req *computepb.ListInstancesR
 	from := getPage(req.PageToken)
 	iter := &simInstanceIter{instances: make([]*computepb.Instance, 0)}
 
-	for indx = from; indx < from+int(*c.pageSize); indx++ {
+	for indx = from; indx < from+int(*c.pageSize) && indx < len(c.instanceIDs); indx++ {
 		node := c.model.Nodes[c.instanceIDs[indx]]
 		instanceID, err := strconv.ParseUint(node.ID, 10, 64)
 		if err != nil {

--- a/pkg/providers/gcp/provider_sim_test.go
+++ b/pkg/providers/gcp/provider_sim_test.go
@@ -167,7 +167,7 @@ SwitchName=tor2 Nodes=node[21-22]
 		{
 			name:     "Case 7: valid cluster, pagination",
 			model:    clusterModel,
-			pageSize: ptr.Int(2),
+			pageSize: ptr.Int(3),
 			instances: []topology.ComputeInstances{
 				{
 					Region:    "region",

--- a/pkg/providers/oci/provider_sim.go
+++ b/pkg/providers/oci/provider_sim.go
@@ -87,7 +87,7 @@ func (c *simClient) ListComputeHosts(ctx context.Context, req core.ListComputeHo
 
 	var indx int
 	from := getPage(req.Page)
-	for indx = from; indx < from+*c.pageSize; indx++ {
+	for indx = from; indx < from+*c.pageSize && indx < len(c.instanceIDs); indx++ {
 		node := c.model.Nodes[c.instanceIDs[indx]]
 		host := core.ComputeHostSummary{
 			Id:         ptr.String(node.ID),

--- a/pkg/providers/oci/provider_sim_test.go
+++ b/pkg/providers/oci/provider_sim_test.go
@@ -166,7 +166,7 @@ SwitchName=switch.1.2 Nodes=node[21-22]
 					Instances: map[string]string{"n11": "node11", "n12": "node12", "n21": "node21", "n22": "node22", "n31": "node31"},
 				},
 			},
-			pageSize: ptr.Int(2),
+			pageSize: ptr.Int(3),
 			params:   map[string]any{"plugin": "topology/block"},
 			topology: `# block001=nvl1
 BlockName=block001 Nodes=node[11-12]


### PR DESCRIPTION
Log the effective AWS page size, use provider defaults for non-positive
values, and prevent GCP and OCI simulations from indexing past partial
final pages.