### PR TITLE
docs(reference): add KEP-5732 forward reference in node-labels.md

### DIFF
--- a/docs/reference/node-labels.md
+++ b/docs/reference/node-labels.md
@@ -119,7 +119,9 @@ without a usable source value retain the provider-derived labels.
 
 ### Relationship to upstream standardization
 
-[KEP-4962: Standardizing the Representation of Cluster Network Topology](https://github.com/kubernetes/enhancements/issues/4962) proposed reserved label keys under the `topology.kubernetes.io/` namespace, but it was closed without being adopted. Its active successor, [KEP-5732](https://github.com/kubernetes/enhancements/issues/5732), targets alpha in Kubernetes v1.36 and takes a similar approach to exposing network topology through standard label keys. Topograph therefore publishes its topology contract under the project-controlled, vendor-neutral `fabric.topograph.run/*` and `accelerator.topograph.run/*` namespaces. If KEP-5732 or a successor reaches stable, Topograph will evaluate aligning with or publishing those keys alongside its project-scoped labels.
+[KEP-4962: Standardizing the Representation of Cluster Network Topology](https://github.com/kubernetes/enhancements/issues/4962) proposed reserved label keys under the `topology.kubernetes.io/` namespace, but it was closed without being adopted. Topograph therefore publishes its topology contract under the project-controlled, vendor-neutral `fabric.topograph.run/*` and `accelerator.topograph.run/*` namespaces. If Kubernetes adopts stable standard topology label keys in the future, Topograph will evaluate aligning with or publishing those keys alongside its project-scoped labels.
+
+A related upstream effort, [KEP-5732: Topology Aware Scheduling](https://github.com/kubernetes/enhancements/issues/5732) (beta in Kubernetes v1.37), introduces topology-aware workload scheduling that consumes existing node labels via a caller-provided key. It does not define a new label namespace — operators point it at whatever label keys are present, including Topograph's `fabric.topograph.run/*` keys.
 
 ## Without Topograph
 

--- a/docs/reference/node-labels.md
+++ b/docs/reference/node-labels.md
@@ -117,9 +117,9 @@ the k8s engine preserves that existing source label as authoritative and omits
 its managed accelerator domain and sub-domain labels for the node. Nodes
 without a usable source value retain the provider-derived labels.
 
-### Relationship to upstream standardization (KEP-4962)
+### Relationship to upstream standardization
 
-[KEP-4962: Standardizing the Representation of Cluster Network Topology](https://github.com/kubernetes/enhancements/issues/4962) proposed reserved label keys under the `topology.kubernetes.io/` namespace, but it was closed without being adopted. Topograph therefore publishes its topology contract under the project-controlled, vendor-neutral `fabric.topograph.run/*` and `accelerator.topograph.run/*` namespaces. If Kubernetes adopts stable standard keys in the future, Topograph will evaluate aligning with or publishing those keys alongside its project-scoped labels.
+[KEP-4962: Standardizing the Representation of Cluster Network Topology](https://github.com/kubernetes/enhancements/issues/4962) proposed reserved label keys under the `topology.kubernetes.io/` namespace, but it was closed without being adopted. Its active successor, [KEP-5732](https://github.com/kubernetes/enhancements/issues/5732), targets alpha in Kubernetes v1.36 and takes a similar approach to exposing network topology through standard label keys. Topograph therefore publishes its topology contract under the project-controlled, vendor-neutral `fabric.topograph.run/*` and `accelerator.topograph.run/*` namespaces. If KEP-5732 or a successor reaches stable, Topograph will evaluate aligning with or publishing those keys alongside its project-scoped labels.
 
 ## Without Topograph
 


### PR DESCRIPTION
## Summary

- KEP-4962 (Standardizing Cluster Network Topology) was closed without adoption. The section in `node-labels.md` already correctly noted this, but didn't name its active successor.
- KEP-5732 is the live follow-on, targeting alpha in Kubernetes v1.36. This PR adds it by name so readers have a concrete pointer to the upstream standardization work in progress.

## Test plan

- [ ] Docs-only change; no code paths affected
- [ ] Fern preview renders correctly (auto-generated by CI bot)
