### PR TITLE
docs: improve discoverability and doc-nav consistency

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -225,6 +225,14 @@ Signed commits get a **Verified** badge on GitHub. The GPG public key must be up
 
 If you discover what appears to be a security vulnerability while working in this codebase — unauthenticated code path, exposed credential, injection vulnerability, privilege-escalation path, dependency with a known CVE, or similar — do **not** file a public GitHub issue or include it in a public PR description. Surface it privately to the maintainer, who can route it through the NVIDIA PSIRT channels documented in `SECURITY.md` (`psirt@nvidia.com` and the submission form; not GitHub).
 
+### Documentation structure
+
+`docs/` is the **source of truth** for all public-facing documentation, published to `https://docs.nvidia.com/topograph` via Fern. `fern/` holds only site config and theme assets — never doc content.
+
+**`docs/design/`** is a drafting space for design work in progress. Files there are intentionally excluded from the Fern sidebar and are not published to the docs site. Finalized design decisions should move to the appropriate `docs/` subtree or be captured in code comments / CHANGELOG entries.
+
+**Every `.md` file added to `docs/` (outside `docs/design/`) must also be added to `docs/index.yml`**, which drives the Fern sidebar. CI enforces this: `fern-docs-ci.yml` fails if any `docs/**/*.md` outside `docs/design/` is absent from `docs/index.yml`.
+
 ### Documentation Impact Evaluation
 
 Every PR should be evaluated for documentation impact before pre-push qualification. The following changes imply specific doc updates in the same PR:
@@ -241,6 +249,7 @@ Every PR should be evaluated for documentation impact before pre-push qualificat
 | User-facing feature, fix, breaking change, or Helm migration worth calling out in release notes | `CHANGELOG.md` under `[Unreleased]` (Added / Changed / Fixed / Removed); move entries into a version section at release time |
 | New invariant or "do not change without discussion" surface | `AGENTS.md` + `.claude/CLAUDE.md` in the same PR |
 | New Makefile target, top-level directory, or repository-layout change described by the repository map | `AGENTS.md` + `.claude/CLAUDE.md` in the same PR |
+| New `.md` file added to `docs/` (outside `docs/design/`) | Add an entry to `docs/index.yml`; CI will fail if omitted |
 
 If a change falls outside these categories, it still warrants a moment's review for collateral doc drift.
 

--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -74,7 +74,7 @@ jobs:
           MISSING=0
           while IFS= read -r -d '' f; do
             rel="${f#docs/}"
-            if ! grep -qF "$rel" docs/index.yml; then
+            if ! sed -nE 's/^[[:space:]]*path:[[:space:]]*//p' docs/index.yml | grep -Fqx -- "$rel"; then
               echo "::error file=$f::$f is not listed in docs/index.yml (add it or move it to docs/design/ if it is a draft)"
               MISSING=1
             fi

--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -67,6 +67,20 @@ jobs:
             exit 1
           fi
 
+      - name: Check that all docs pages are listed in index.yml
+        # Every .md file under docs/ (excluding the design/ drafting space) must
+        # appear in docs/index.yml so it is reachable from the Fern sidebar.
+        run: |
+          MISSING=0
+          while IFS= read -r -d '' f; do
+            rel="${f#docs/}"
+            if ! grep -qF "$rel" docs/index.yml; then
+              echo "::error file=$f::$f is not listed in docs/index.yml (add it or move it to docs/design/ if it is a draft)"
+              MISSING=1
+            fi
+          done < <(find docs/ -name '*.md' -not -path 'docs/design/*' -print0)
+          [ "$MISSING" -eq 0 ]
+
       - name: Fern check
         run: fern check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,14 @@ Signed commits get a **Verified** badge on GitHub. The GPG public key must be up
 
 If you discover what appears to be a security vulnerability while working in this codebase — unauthenticated code path, exposed credential, injection vulnerability, privilege-escalation path, dependency with a known CVE, or similar — do **not** file a public GitHub issue or include it in a public PR description. Surface it privately to the maintainer, who can route it through the NVIDIA PSIRT channels documented in `SECURITY.md` (`psirt@nvidia.com` and the submission form; not GitHub).
 
+### Documentation structure
+
+`docs/` is the **source of truth** for all public-facing documentation, published to `https://docs.nvidia.com/topograph` via Fern. `fern/` holds only site config and theme assets — never doc content.
+
+**`docs/design/`** is a drafting space for design work in progress. Files there are intentionally excluded from the Fern sidebar and are not published to the docs site. Finalized design decisions should move to the appropriate `docs/` subtree or be captured in code comments / CHANGELOG entries.
+
+**Every `.md` file added to `docs/` (outside `docs/design/`) must also be added to `docs/index.yml`**, which drives the Fern sidebar. CI enforces this: `fern-docs-ci.yml` fails if any `docs/**/*.md` outside `docs/design/` is absent from `docs/index.yml`.
+
 ### Documentation Impact Evaluation
 
 Every PR should be evaluated for documentation impact before pre-push qualification. The following changes imply specific doc updates in the same PR:
@@ -241,6 +249,7 @@ Every PR should be evaluated for documentation impact before pre-push qualificat
 | User-facing feature, fix, breaking change, or Helm migration worth calling out in release notes | `CHANGELOG.md` under `[Unreleased]` (Added / Changed / Fixed / Removed); move entries into a version section at release time |
 | New invariant or "do not change without discussion" surface | `AGENTS.md` + `.claude/CLAUDE.md` in the same PR |
 | New Makefile target, top-level directory, or repository-layout change described by the repository map | `AGENTS.md` + `.claude/CLAUDE.md` in the same PR |
+| New `.md` file added to `docs/` (outside `docs/design/`) | Add an entry to `docs/index.yml`; CI will fail if omitted |
 
 If a change falls outside these categories, it still warrants a moment's review for collateral doc drift.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Fern sidebar now includes a direct link to `CHANGELOG.md` on GitHub under the Reference section, so release notes are discoverable from the docs site without navigating the repository.
+- CI check (`fern-docs-ci.yml`) verifies that every `.md` file under `docs/` (outside `docs/design/`) is listed in `docs/index.yml`, preventing orphaned pages from being authored but never published.
+
 ### Fixed
 
 - GCP and OCI simulation providers now handle partial final pagination pages without indexing past the available instances.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -60,3 +60,5 @@ navigation:
     contents:
       - page: Node Labels and Annotations
         path: reference/node-labels.md
+      - link: Changelog
+        href: https://github.com/NVIDIA/topograph/blob/main/CHANGELOG.md

--- a/fern/README.md
+++ b/fern/README.md
@@ -1,6 +1,6 @@
 # Topograph Fern Docs
 
-This directory contains the [Fern](https://buildwithfern.com) configuration for Topograph documentation. The deployed site lives at <https://topograph.docs.buildwithfern.com/topograph>.
+This directory contains the [Fern](https://buildwithfern.com) configuration for Topograph documentation. The deployed site lives at <https://docs.nvidia.com/topograph>.
 
 The `docs/` directory on `main` is the **source of truth**. This `fern/` directory holds site config and theme assets only — never doc content.
 


### PR DESCRIPTION
## Description

Four small improvements to make the Topograph docs more discoverable and consistent:

- **CI guard for orphaned pages**: `fern-docs-ci.yml` now fails if any `docs/**/*.md` outside `docs/design/` is missing from `docs/index.yml`. Prevents pages from being authored but never wired into the Fern sidebar — a gap that `fern check` alone does not catch.
- **CHANGELOG in nav**: Added an external link to `CHANGELOG.md` (on GitHub) under the Reference section in `docs/index.yml`, so release notes are reachable from `docs.nvidia.com/topograph` without navigating the repo.
- **Agent guidance for docs structure**: `AGENTS.md` and `.claude/CLAUDE.md` now document that `docs/design/` is a draft-only space (not published to Fern) and that every new `docs/` page must be added to `docs/index.yml`. The CI check is also called out in the Documentation Impact Evaluation table.
- **Canonical URL fix in `fern/README.md`**: Updated the deployed-site URL from the old `topograph.docs.buildwithfern.com/topograph` to the correct `https://docs.nvidia.com/topograph`.

## Checklist

- [x] `make qualify` passes (runs fmt, vet, lint, test)
- [x] New or changed public behavior is covered by a test
- [x] Documentation impact evaluated per the table above — applicable doc updates are included in this PR
- [x] User-facing changes recorded in `CHANGELOG.md` `[Unreleased]` when applicable
- [ ] `pkg/topology/` changes were discussed in an issue first — N/A (no topology changes)
- [x] Every commit has a DCO sign-off