### PR TITLE
fix(fern): escape MDX-unsafe chars only outside code fences

### DIFF
--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -70,10 +70,27 @@ jobs:
             if git show-ref --verify --quiet "refs/tags/${version}"; then
               mkdir -p "fern/versions/${version}-content"
               git archive "refs/tags/${version}" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
-              find "fern/versions/${version}-content" -name '*.md' -print0 | xargs -0 -r sed -i \
-                -e 's/{/\\{/g' \
-                -e 's/}/\\}/g' \
-                -e 's/</\&lt;/g'
+              # Escape {, }, < for MDX — but only outside fenced code blocks and inline code spans
+              find "fern/versions/${version}-content" -name '*.md' -print0 | while IFS= read -r -d '' f; do
+                awk '
+                  /^````*/ || /^~~~~*/ { fence = !fence; print; next }
+                  fence { print; next }
+                  {
+                    n = split($0, p, "`")
+                    out = ""
+                    for (i = 1; i <= n; i++) {
+                      if (i % 2 == 1) {
+                        gsub(/{/, "\\{", p[i])
+                        gsub(/}/, "\\}", p[i])
+                        gsub(/</, "\\&lt;", p[i])
+                      }
+                      out = out p[i]
+                      if (i < n) out = out "`"
+                    }
+                    print out
+                  }
+                ' "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+              done
               for subdir in "fern/versions/${version}-content"/*/; do
                 if [ ! -d "${subdir}assets" ] && [ -d "fern/versions/${version}-content/assets" ]; then
                   ln -sf ../assets "${subdir}assets"

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -190,10 +190,27 @@ jobs:
             if git show-ref --verify --quiet "refs/tags/${version}"; then
               mkdir -p "fern/versions/${version}-content"
               git archive "refs/tags/${version}" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
-              find "fern/versions/${version}-content" -name '*.md' -print0 | xargs -0 -r sed -i \
-                -e 's/{/\\{/g' \
-                -e 's/}/\\}/g' \
-                -e 's/</\&lt;/g'
+              # Escape {, }, < for MDX — but only outside fenced code blocks and inline code spans
+              find "fern/versions/${version}-content" -name '*.md' -print0 | while IFS= read -r -d '' f; do
+                awk '
+                  /^````*/ || /^~~~~*/ { fence = !fence; print; next }
+                  fence { print; next }
+                  {
+                    n = split($0, p, "`")
+                    out = ""
+                    for (i = 1; i <= n; i++) {
+                      if (i % 2 == 1) {
+                        gsub(/{/, "\\{", p[i])
+                        gsub(/}/, "\\}", p[i])
+                        gsub(/</, "\\&lt;", p[i])
+                      }
+                      out = out p[i]
+                      if (i < n) out = out "`"
+                    }
+                    print out
+                  }
+                ' "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+              done
               # Fix broken relative image paths in older tags
               for subdir in "fern/versions/${version}-content"/*/; do
                 if [ ! -d "${subdir}assets" ] && [ -d "fern/versions/${version}-content/assets" ]; then


### PR DESCRIPTION
## Description

closes #480

The `sed`-based escaping of `{`, `}`, and `<` in frozen version content was applied globally, mangling JSON/YAML/shell examples inside fenced code blocks and inline code spans. Replaced with `awk` that tracks fence state and splits on backticks to preserve code content.

Affected workflows:
- `fern-docs-preview-build.yml`
- `publish-fern-docs.yml`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).