### PR TITLE
docs(readme): replace badges with consistent flat-square Shields.io row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- README badges replaced with a consistent flat-square Shields.io row: Go CI, Coverage, Chart Tests, K8s Tests, Release, and License — each linked to its source and using a shared dark label color aligned with the Topograph logo palette.
 - Documentation diagrams for architecture, Kubernetes, Slinky, Slurm topology formats, and engine outputs now ship as community-variant SVG and PNG assets with automatic dark/light mode switching (`<picture>` / `prefers-color-scheme` in docs; `#gh-light-mode-only` / `#gh-dark-mode-only` in README).
 - Topograph logo variants for light mode (`topograph-logo-color`), dark mode (`topograph-logo-color-dark`), reversed black, and reversed white added to `docs/assets/`. The `README.md` logo now switches between color and color-dark automatically based on the viewer's GitHub theme preference.
 - Fern sidebar now includes a direct link to `CHANGELOG.md` on GitHub under the Reference section, so release notes are discoverable from the docs site without navigating the repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- README badges replaced with a consistent flat-square Shields.io row: Go CI, Coverage, Chart Tests, K8s Tests, Release, and License — each linked to its source and using a shared dark label color aligned with the Topograph logo palette.
+- README badges replaced with a consistent flat-square Shields.io row: Docs, Go CI, Coverage, Chart Tests, K8s Tests, Release, and License — each linked to its source and using a shared dark label color aligned with the Topograph logo palette.
 - Documentation diagrams for architecture, Kubernetes, Slinky, Slurm topology formats, and engine outputs now ship as community-variant SVG and PNG assets with automatic dark/light mode switching (`<picture>` / `prefers-color-scheme` in docs; `#gh-light-mode-only` / `#gh-dark-mode-only` in README).
 - Topograph logo variants for light mode (`topograph-logo-color`), dark mode (`topograph-logo-color-dark`), reversed black, and reversed white added to `docs/assets/`. The `README.md` logo now switches between color and color-dark automatically based on the viewer's GitHub theme preference.
 - Fern sidebar now includes a direct link to `CHANGELOG.md` on GitHub under the Reference section, so release notes are discoverable from the docs site without navigating the repository.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 [![Coverage](https://img.shields.io/codecov/c/github/NVIDIA/topograph/main?label=coverage&style=flat-square&labelColor=172033&logo=codecov&logoColor=white)](https://codecov.io/gh/NVIDIA/topograph)
 [![Chart Tests](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/chart-test.yaml?label=chart%20tests&style=flat-square&labelColor=172033&logo=helm&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/chart-test.yaml)
 [![K8s Tests](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/k8s-test.yaml?label=k8s%20tests&style=flat-square&labelColor=172033&logo=kubernetes&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/k8s-test.yaml)
-[![Release](https://img.shields.io/github/v/release/NVIDIA/topograph?label=release&style=flat-square&labelColor=172033&color=2563EB&logo=github&logoColor=white)](https://github.com/NVIDIA/topograph/releases)
-[![License](https://img.shields.io/github/license/NVIDIA/topograph?label=license&style=flat-square&labelColor=172033&color=0891B2&logo=apache&logoColor=white)](https://github.com/NVIDIA/topograph/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/NVIDIA/topograph?label=release&style=flat-square&labelColor=172033&color=2563EB)](https://github.com/NVIDIA/topograph/releases)
+[![License](https://img.shields.io/github/license/NVIDIA/topograph?label=license&style=flat-square&labelColor=172033&color=0891B2)](https://github.com/NVIDIA/topograph/blob/main/LICENSE)
 [![Docs](https://img.shields.io/badge/docs-latest-blue?style=flat-square&labelColor=172033&logo=nvidia&logoColor=white)](https://docs.nvidia.com/topograph)
 
 Topograph is a component that discovers the physical network topology of a cluster and exposes it to schedulers, enabling topology-aware scheduling decisions. It abstracts multiple topology sources and translates them into the format required by each scheduler.

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 
 # Topograph
 
-[![Docs](https://img.shields.io/badge/docs-docs.nvidia.com%2Ftopograph-blue?style=flat-square&labelColor=172033)](https://docs.nvidia.com/topograph)
 [![Go CI](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/go.yml?branch=main&label=go%20ci&style=flat-square&labelColor=172033&logo=github&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/go.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/NVIDIA/topograph/main?label=coverage&style=flat-square&labelColor=172033&logo=codecov&logoColor=white)](https://codecov.io/gh/NVIDIA/topograph)
-[![Chart Tests](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/chart-test.yaml?branch=main&label=chart%20tests&style=flat-square&labelColor=172033&logo=helm&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/chart-test.yaml)
-[![K8s Tests](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/k8s-test.yaml?branch=main&label=k8s%20tests&style=flat-square&labelColor=172033&logo=kubernetes&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/k8s-test.yaml)
+[![Chart Tests](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/chart-test.yaml?label=chart%20tests&style=flat-square&labelColor=172033&logo=helm&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/chart-test.yaml)
+[![K8s Tests](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/k8s-test.yaml?label=k8s%20tests&style=flat-square&labelColor=172033&logo=kubernetes&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/k8s-test.yaml)
 [![Release](https://img.shields.io/github/v/release/NVIDIA/topograph?label=release&style=flat-square&labelColor=172033&color=2563EB)](https://github.com/NVIDIA/topograph/releases)
 [![License](https://img.shields.io/github/license/NVIDIA/topograph?label=license&style=flat-square&labelColor=172033&color=0891B2)](https://github.com/NVIDIA/topograph/blob/main/LICENSE)
+[![Docs](https://img.shields.io/badge/docs-docs.nvidia.com%2Ftopograph-blue?style=flat-square&labelColor=172033)](https://docs.nvidia.com/topograph)
 
 Topograph is a component that discovers the physical network topology of a cluster and exposes it to schedulers, enabling topology-aware scheduling decisions. It abstracts multiple topology sources and translates them into the format required by each scheduler.
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 [![Coverage](https://img.shields.io/codecov/c/github/NVIDIA/topograph/main?label=coverage&style=flat-square&labelColor=172033&logo=codecov&logoColor=white)](https://codecov.io/gh/NVIDIA/topograph)
 [![Chart Tests](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/chart-test.yaml?label=chart%20tests&style=flat-square&labelColor=172033&logo=helm&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/chart-test.yaml)
 [![K8s Tests](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/k8s-test.yaml?label=k8s%20tests&style=flat-square&labelColor=172033&logo=kubernetes&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/k8s-test.yaml)
-[![Release](https://img.shields.io/github/v/release/NVIDIA/topograph?label=release&style=flat-square&labelColor=172033&color=2563EB)](https://github.com/NVIDIA/topograph/releases)
-[![License](https://img.shields.io/github/license/NVIDIA/topograph?label=license&style=flat-square&labelColor=172033&color=0891B2)](https://github.com/NVIDIA/topograph/blob/main/LICENSE)
-[![Docs](https://img.shields.io/badge/docs-docs.nvidia.com%2Ftopograph-blue?style=flat-square&labelColor=172033)](https://docs.nvidia.com/topograph)
+[![Release](https://img.shields.io/github/v/release/NVIDIA/topograph?label=release&style=flat-square&labelColor=172033&color=2563EB&logo=github&logoColor=white)](https://github.com/NVIDIA/topograph/releases)
+[![License](https://img.shields.io/github/license/NVIDIA/topograph?label=license&style=flat-square&labelColor=172033&color=0891B2&logo=apache&logoColor=white)](https://github.com/NVIDIA/topograph/blob/main/LICENSE)
+[![Docs](https://img.shields.io/badge/docs-docs.nvidia.com%2Ftopograph-blue?style=flat-square&labelColor=172033&logo=nvidia&logoColor=white)](https://docs.nvidia.com/topograph)
 
 Topograph is a component that discovers the physical network topology of a cluster and exposes it to schedulers, enabling topology-aware scheduling decisions. It abstracts multiple topology sources and translates them into the format required by each scheduler.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 # Topograph
 
+[![Docs](https://img.shields.io/badge/docs-docs.nvidia.com%2Ftopograph-blue?style=flat-square&labelColor=172033)](https://docs.nvidia.com/topograph)
 [![Go CI](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/go.yml?branch=main&label=go%20ci&style=flat-square&labelColor=172033&logo=github&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/go.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/NVIDIA/topograph/main?label=coverage&style=flat-square&labelColor=172033&logo=codecov&logoColor=white)](https://codecov.io/gh/NVIDIA/topograph)
 [![Chart Tests](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/chart-test.yaml?branch=main&label=chart%20tests&style=flat-square&labelColor=172033&logo=helm&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/chart-test.yaml)

--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@
 
 # Topograph
 
-![Build Status](https://github.com/NVIDIA/topograph/actions/workflows/go.yml/badge.svg)
-![Codecov](https://codecov.io/gh/NVIDIA/topograph/branch/main/graph/badge.svg)
-![Static Badge](https://img.shields.io/badge/license-Apache_2.0-green)
+[![Go CI](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/go.yml?branch=main&label=go%20ci&style=flat-square&labelColor=172033&logo=github&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/go.yml)
+[![Coverage](https://img.shields.io/codecov/c/github/NVIDIA/topograph/main?label=coverage&style=flat-square&labelColor=172033&logo=codecov&logoColor=white)](https://codecov.io/gh/NVIDIA/topograph)
+[![Chart Tests](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/chart-test.yaml?branch=main&label=chart%20tests&style=flat-square&labelColor=172033&logo=helm&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/chart-test.yaml)
+[![K8s Tests](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/k8s-test.yaml?branch=main&label=k8s%20tests&style=flat-square&labelColor=172033&logo=kubernetes&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/k8s-test.yaml)
+[![Release](https://img.shields.io/github/v/release/NVIDIA/topograph?label=release&style=flat-square&labelColor=172033&color=2563EB)](https://github.com/NVIDIA/topograph/releases)
+[![License](https://img.shields.io/github/license/NVIDIA/topograph?label=license&style=flat-square&labelColor=172033&color=0891B2)](https://github.com/NVIDIA/topograph/blob/main/LICENSE)
 
 Topograph is a component that discovers the physical network topology of a cluster and exposes it to schedulers, enabling topology-aware scheduling decisions. It abstracts multiple topology sources and translates them into the format required by each scheduler.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![K8s Tests](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/k8s-test.yaml?label=k8s%20tests&style=flat-square&labelColor=172033&logo=kubernetes&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/k8s-test.yaml)
 [![Release](https://img.shields.io/github/v/release/NVIDIA/topograph?label=release&style=flat-square&labelColor=172033&color=2563EB&logo=github&logoColor=white)](https://github.com/NVIDIA/topograph/releases)
 [![License](https://img.shields.io/github/license/NVIDIA/topograph?label=license&style=flat-square&labelColor=172033&color=0891B2&logo=apache&logoColor=white)](https://github.com/NVIDIA/topograph/blob/main/LICENSE)
-[![Docs](https://img.shields.io/badge/docs-docs.nvidia.com%2Ftopograph-blue?style=flat-square&labelColor=172033&logo=nvidia&logoColor=white)](https://docs.nvidia.com/topograph)
+[![Docs](https://img.shields.io/badge/docs-latest-blue?style=flat-square&labelColor=172033&logo=nvidia&logoColor=white)](https://docs.nvidia.com/topograph)
 
 Topograph is a component that discovers the physical network topology of a cluster and exposes it to schedulers, enabling topology-aware scheduling decisions. It abstracts multiple topology sources and translates them into the format required by each scheduler.
 


### PR DESCRIPTION
## Description

Replaces the three legacy README badges with a uniform six-badge flat-square Shields.io row.

**Before:**
```
![Build Status](https://github.com/NVIDIA/topograph/actions/workflows/go.yml/badge.svg)
![Codecov](https://codecov.io/gh/NVIDIA/topograph/branch/main/graph/badge.svg)
![Static Badge](https://img.shields.io/badge/license-Apache_2.0-green)
```

**After:**

[![Go CI](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/go.yml?branch=main&label=go%20ci&style=flat-square&labelColor=172033&logo=github&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/go.yml)
[![Coverage](https://img.shields.io/codecov/c/github/NVIDIA/topograph/main?label=coverage&style=flat-square&labelColor=172033&logo=codecov&logoColor=white)](https://codecov.io/gh/NVIDIA/topograph)
[![Chart Tests](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/chart-test.yaml?branch=main&label=chart%20tests&style=flat-square&labelColor=172033&logo=helm&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/chart-test.yaml)
[![K8s Tests](https://img.shields.io/github/actions/workflow/status/NVIDIA/topograph/k8s-test.yaml?branch=main&label=k8s%20tests&style=flat-square&labelColor=172033&logo=kubernetes&logoColor=white)](https://github.com/NVIDIA/topograph/actions/workflows/k8s-test.yaml)
[![Release](https://img.shields.io/github/v/release/NVIDIA/topograph?label=release&style=flat-square&labelColor=172033&color=2563EB)](https://github.com/NVIDIA/topograph/releases)
[![License](https://img.shields.io/github/license/NVIDIA/topograph?label=license&style=flat-square&labelColor=172033&color=0891B2)](https://github.com/NVIDIA/topograph/blob/main/LICENSE)

**Design notes:**
- All badges use `style=flat-square` and shared `labelColor=172033` (aligned with the Topograph logo dark palette, readable in GitHub light and dark modes)
- Workflow status badges use `?branch=main` so they reflect the main branch state rather than the default-branch heuristic
- Chart Tests and K8s Tests surface CI signal that was previously invisible from the README
- Release badge tracks the latest semver tag
- License badge reads the repo license dynamically via the GitHub API rather than a hardcoded string
- All workflow filenames verified against `.github/workflows/` before use

**Not included (intentional):**
- OpenSSF Scorecard badge — deferred until the Scorecard workflow is added and has published results on main

## Checklist

- [x] `make qualify` passes (runs fmt, vet, lint, test)
- [x] New or changed public behavior is covered by a test
- [x] Documentation impact evaluated — README only, no docs pages affected
- [x] User-facing changes recorded in `CHANGELOG.md` `[Unreleased]`
- [ ] `pkg/topology/` changes were discussed in an issue first — N/A
- [x] Every commit has a DCO sign-off