### PR TITLE
test: add coverage for httperr and registry packages

### DIFF
--- a/internal/httperr/http_error_test.go
+++ b/internal/httperr/http_error_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/httperr/http_error_test.go
+++ b/internal/httperr/http_error_test.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025-2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package httperr
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewError(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+		msg  string
+	}{
+		{name: "bad request", code: http.StatusBadRequest, msg: "invalid input"},
+		{name: "not found", code: http.StatusNotFound, msg: "resource not found"},
+		{name: "internal error", code: http.StatusInternalServerError, msg: "something went wrong"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewError(tt.code, tt.msg)
+			require.NotNil(t, err)
+			require.Equal(t, tt.code, err.Code())
+			require.Equal(t, tt.msg, err.Error())
+		})
+	}
+}

--- a/internal/httperr/http_error_test.go
+++ b/internal/httperr/http_error_test.go
@@ -1,6 +1,17 @@
 /*
- * Copyright 2025-2026 NVIDIA CORPORATION
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package httperr

--- a/internal/httpreq/httpreq_test.go
+++ b/internal/httpreq/httpreq_test.go
@@ -249,6 +249,7 @@ func TestDoRequest(t *testing.T) {
 		resp, body, err := DoRequest(f, false)
 		require.NotNil(t, err)
 		require.Equal(t, http.StatusNotFound, err.Code())
+		require.Equal(t, "not found", err.Error())
 		require.NotNil(t, resp)
 		require.Equal(t, []byte("not found"), body)
 	})

--- a/internal/httpreq/httpreq_test.go
+++ b/internal/httpreq/httpreq_test.go
@@ -8,6 +8,7 @@ package httpreq
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -197,6 +198,111 @@ func TestGetURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDoRequest(t *testing.T) {
+	t.Run("request func returns error", func(t *testing.T) {
+		f := func() (*http.Request, *httperr.Error) {
+			return nil, httperr.NewError(http.StatusBadRequest, "bad input")
+		}
+		resp, body, err := DoRequest(f, false)
+		require.Nil(t, resp)
+		require.Nil(t, body)
+		require.NotNil(t, err)
+		require.Equal(t, http.StatusBadRequest, err.Code())
+	})
+
+	t.Run("2xx response returns body and no error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}))
+		defer srv.Close()
+
+		f := func() (*http.Request, *httperr.Error) {
+			req, e := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+			if e != nil {
+				return nil, httperr.NewError(http.StatusInternalServerError, e.Error())
+			}
+			return req, nil
+		}
+		resp, body, err := DoRequest(f, false)
+		require.Nil(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, []byte("ok"), body)
+	})
+
+	t.Run("non-2xx response returns body and error with that status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("not found"))
+		}))
+		defer srv.Close()
+
+		f := func() (*http.Request, *httperr.Error) {
+			req, e := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+			if e != nil {
+				return nil, httperr.NewError(http.StatusInternalServerError, e.Error())
+			}
+			return req, nil
+		}
+		resp, body, err := DoRequest(f, false)
+		require.NotNil(t, err)
+		require.Equal(t, http.StatusNotFound, err.Code())
+		require.NotNil(t, resp)
+		require.Equal(t, []byte("not found"), body)
+	})
+
+	t.Run("transport error returns 502", func(t *testing.T) {
+		f := func() (*http.Request, *httperr.Error) {
+			req, e := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1:1", nil)
+			if e != nil {
+				return nil, httperr.NewError(http.StatusInternalServerError, e.Error())
+			}
+			return req, nil
+		}
+		_, _, err := DoRequest(f, false)
+		require.NotNil(t, err)
+		require.Equal(t, http.StatusBadGateway, err.Code())
+	})
+
+	t.Run("insecureSkipVerify works against TLS server", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("tls-ok"))
+		}))
+		defer srv.Close()
+
+		f := func() (*http.Request, *httperr.Error) {
+			req, e := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+			if e != nil {
+				return nil, httperr.NewError(http.StatusInternalServerError, e.Error())
+			}
+			return req, nil
+		}
+		resp, body, err := DoRequest(f, true)
+		require.Nil(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, []byte("tls-ok"), body)
+	})
+}
+
+func TestGetRequestFunc(t *testing.T) {
+	ctx := context.Background()
+	f := GetRequestFunc(ctx, http.MethodGet,
+		map[string]string{"Authorization": "Bearer token"},
+		map[string]string{"page": "1"},
+		nil,
+		"http://localhost",
+		"v1", "resource",
+	)
+	req, err := f()
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, http.MethodGet, req.Method)
+	require.Equal(t, "Bearer token", req.Header.Get("Authorization"))
+	require.Equal(t, "1", req.URL.Query().Get("page"))
+	require.Equal(t, "/v1/resource", req.URL.Path)
 }
 
 func TestGetNextBackoff(t *testing.T) {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,6 +1,17 @@
 /*
- * Copyright 2025-2026 NVIDIA CORPORATION
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package registry

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025-2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package registry
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviders(t *testing.T) {
+	known := []string{
+		"aws", "aws-sim",
+		"infiniband-bm", "infiniband-k8s",
+		"dra",
+		"gcp", "gcp-sim",
+		"oci", "oci-imds", "oci-sim",
+		"nebius", "nebius-sim",
+		"netq",
+		"lambdai", "lambdai-sim",
+		"dsx-sim",
+		"nscale", "nscale-sim",
+		"test",
+	}
+
+	for _, name := range known {
+		t.Run(name, func(t *testing.T) {
+			loader, err := Providers.Get(name)
+			require.Nil(t, err, "expected %q to be registered", name)
+			require.NotNil(t, loader)
+		})
+	}
+
+	t.Run("unknown provider returns 400", func(t *testing.T) {
+		_, err := Providers.Get("nonexistent")
+		require.NotNil(t, err)
+		require.Equal(t, http.StatusBadRequest, err.Code())
+	})
+}
+
+func TestEngines(t *testing.T) {
+	known := []string{"k8s", "nfd", "graph", "slurm", "slinky"}
+
+	for _, name := range known {
+		t.Run(name, func(t *testing.T) {
+			loader, err := Engines.Get(name)
+			require.Nil(t, err, "expected %q to be registered", name)
+			require.NotNil(t, loader)
+		})
+	}
+
+	t.Run("unknown engine returns 400", func(t *testing.T) {
+		_, err := Engines.Get("nonexistent")
+		require.NotNil(t, err)
+		require.Equal(t, http.StatusBadRequest, err.Code())
+	})
+}


### PR DESCRIPTION
## Description

Adds test files for two packages that had zero coverage.

### `internal/httperr`

`NewError`, `Error`, and `Code` were uncovered despite being called at every provider/engine boundary. The new test exercises all three methods across several HTTP status codes, bringing the package to 100%.

### `pkg/registry`

The central provider and engine wiring had no tests. The new test asserts that every registered name resolves to a non-nil loader, and that unregistered names return a `400 Bad Request` error — covering the registry initialization, the `Get` happy path for every provider and engine, and the `Get` error path in both `providers.Registry` and `engines.Registry`.

## Checklist

- [x] `make qualify` passes (runs fmt, vet, lint, test)
- [x] New or changed public behavior is covered by a test
- [x] Documentation impact evaluated — no doc changes needed
- [x] User-facing changes recorded in `CHANGELOG.md` `[Unreleased]` when applicable — tests only
- [ ] `pkg/topology/` changes were discussed in an issue first — N/A
- [x] Every commit has a DCO sign-off