### PR TITLE
ci(go): run the Go workflow on pushes to main

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,7 @@ name: Go
 on:
   push:
     branches:
+      - main
       - "pull-request/[0-9]+"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- The `Go` workflow now also runs on pushes to `main`, so Codecov receives a coverage report for every merged commit. Merges are squashed, so the SHA that lands on `main` no longer matches the `pull-request/<n>` SHA that uploaded coverage; without a `main` trigger, Codecov's `main` branch had gone stale since 2026-07-06 and the README coverage badge reported a figure roughly six points below actual coverage.
 - GCP and OCI simulation providers now handle partial final pagination pages without indexing past the available instances.
 - Non-positive `pageSize` configuration values now emit a warning and use the provider default instead of reaching provider APIs and simulation pagination loops.
 


### PR DESCRIPTION
## Description

The Go workflow (`go.yml`) triggered only on `pull-request/[0-9]+` branches. When merges preserved PR commit SHAs, Codecov attributed those uploads to `main` once the commits landed. Merges are now squashed, so the SHA on `main` differs from the one that uploaded coverage and no report reaches the `main` branch at all.

Codecov's `main` line has been frozen at 72.15% since 2026-07-06 while PR branches report ~78%, and the README coverage badge — which reads `main` — understates coverage by roughly six points.

Adding `main` to the push trigger gives every merged commit its own upload. Coverage status checks are unaffected: `codecov.yml` sets `only_pulls: true` for both the project and patch statuses, so `main` builds report coverage without gating anything.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes — N/A (CI config only)
- [x] The documentation is up to date with these changes — N/A
- [x] All commits are signed off per DCO (`git commit -s`).