### PR TITLE
test: expand coverage for internal/k8s, slurm engine, dra provider, infiniband provider, and add goleak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
+	go.uber.org/goleak v1.3.0
 	golang.org/x/sync v0.21.0
 	google.golang.org/api v0.276.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/internal/k8s/utils_test.go
+++ b/internal/k8s/utils_test.go
@@ -136,6 +136,15 @@ func TestGetDaemonSetPods(t *testing.T) {
 		listAction := actions[len(actions)-1].(k8stesting.ListAction)
 		require.Equal(t, "spec.nodeName=node-1", listAction.GetListRestrictions().Fields.String())
 	})
+
+	t.Run("pod list error is returned when daemonset get succeeds", func(t *testing.T) {
+		errClient := fake.NewSimpleClientset(ds)
+		errClient.PrependReactor("list", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("pods unavailable")
+		})
+		_, err := GetDaemonSetPods(context.Background(), errClient, "broker", "default", "")
+		require.ErrorContains(t, err, "pods unavailable")
+	})
 }
 
 func TestGetComputeInstances(t *testing.T) {

--- a/internal/k8s/utils_test.go
+++ b/internal/k8s/utils_test.go
@@ -65,10 +65,21 @@ func TestGetPodsByLabels(t *testing.T) {
 	}
 	client := fake.NewSimpleClientset(pod1, pod2)
 
-	pods, err := GetPodsByLabels(context.Background(), client, "default", map[string]string{"app": "broker"})
-	require.NoError(t, err)
-	require.Len(t, pods.Items, 1)
-	require.Equal(t, "pod-1", pods.Items[0].Name)
+	t.Run("returns matching pods", func(t *testing.T) {
+		pods, err := GetPodsByLabels(context.Background(), client, "default", map[string]string{"app": "broker"})
+		require.NoError(t, err)
+		require.Len(t, pods.Items, 1)
+		require.Equal(t, "pod-1", pods.Items[0].Name)
+	})
+
+	t.Run("api error is returned", func(t *testing.T) {
+		errClient := fake.NewSimpleClientset()
+		errClient.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("pods unavailable")
+		})
+		_, err := GetPodsByLabels(context.Background(), errClient, "default", map[string]string{"app": "broker"})
+		require.ErrorContains(t, err, "pods unavailable")
+	})
 }
 
 func TestGetDaemonSetPods(t *testing.T) {
@@ -96,12 +107,20 @@ func TestGetDaemonSetPods(t *testing.T) {
 		},
 		Spec: corev1.PodSpec{NodeName: "node-2"},
 	}
+	// The fake client does not enforce label/field selectors server-side.
+	// Selector correctness is verified via Actions() inspection below.
 	client := fake.NewSimpleClientset(ds, pod1, pod2)
 
 	t.Run("all pods without node filter", func(t *testing.T) {
+		client.ClearActions()
 		pods, err := GetDaemonSetPods(context.Background(), client, "broker", "default", "")
 		require.NoError(t, err)
 		require.Len(t, pods.Items, 2)
+		// verify label selector was sent — fake client does not enforce it server-side
+		actions := client.Actions()
+		listAction := actions[len(actions)-1].(k8stesting.ListAction)
+		require.Contains(t, listAction.GetListRestrictions().Labels.String(), "app=broker")
+		require.Empty(t, listAction.GetListRestrictions().Fields.String())
 	})
 
 	t.Run("daemonset not found returns error", func(t *testing.T) {
@@ -109,11 +128,13 @@ func TestGetDaemonSetPods(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("nodename filter is applied", func(t *testing.T) {
-		pods, err := GetDaemonSetPods(context.Background(), client, "broker", "default", "node-1")
+	t.Run("nodename field selector is sent", func(t *testing.T) {
+		client.ClearActions()
+		_, err := GetDaemonSetPods(context.Background(), client, "broker", "default", "node-1")
 		require.NoError(t, err)
-		// fake client doesn't enforce field selectors server-side, but the call succeeds
-		require.NotNil(t, pods)
+		actions := client.Actions()
+		listAction := actions[len(actions)-1].(k8stesting.ListAction)
+		require.Equal(t, "spec.nodeName=node-1", listAction.GetListRestrictions().Fields.String())
 	})
 }
 
@@ -159,6 +180,40 @@ func TestGetComputeInstances(t *testing.T) {
 		}
 		require.Equal(t, map[string]string{"i-001": "node-1", "i-002": "node-2"}, byRegion["us-east-1"])
 		require.Equal(t, map[string]string{"i-003": "node-3"}, byRegion["us-west-2"])
+	})
+
+	t.Run("incomplete nodes are skipped alongside valid ones", func(t *testing.T) {
+		nodes := &corev1.NodeList{
+			Items: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "good-node",
+						Annotations: map[string]string{
+							topology.KeyNodeInstance: "i-good",
+							topology.KeyNodeRegion:   "us-east-1",
+						},
+					},
+				},
+				{
+					// missing instance annotation
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "no-instance",
+						Annotations: map[string]string{topology.KeyNodeRegion: "us-east-1"},
+					},
+				},
+				{
+					// missing region annotation
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "no-region",
+						Annotations: map[string]string{topology.KeyNodeInstance: "i-bad"},
+					},
+				},
+			},
+		}
+		cis := GetComputeInstances(nodes)
+		require.Len(t, cis, 1)
+		require.Equal(t, "us-east-1", cis[0].Region)
+		require.Equal(t, map[string]string{"i-good": "good-node"}, cis[0].Instances)
 	})
 
 	t.Run("node missing instance annotation is skipped", func(t *testing.T) {

--- a/internal/k8s/utils_test.go
+++ b/internal/k8s/utils_test.go
@@ -6,12 +6,191 @@
 package k8s
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/NVIDIA/topograph/pkg/topology"
 )
+
+func TestGetNodes(t *testing.T) {
+	node1 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+	node2 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}}
+	client := fake.NewSimpleClientset(node1, node2)
+
+	t.Run("nil options returns all nodes", func(t *testing.T) {
+		nodes, err := GetNodes(context.Background(), client, nil)
+		require.NoError(t, err)
+		require.Len(t, nodes.Items, 2)
+	})
+
+	t.Run("explicit empty options returns all nodes", func(t *testing.T) {
+		nodes, err := GetNodes(context.Background(), client, &metav1.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, nodes.Items, 2)
+	})
+
+	t.Run("api error is returned", func(t *testing.T) {
+		errClient := fake.NewSimpleClientset()
+		errClient.PrependReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("api unavailable")
+		})
+		_, err := GetNodes(context.Background(), errClient, nil)
+		require.ErrorContains(t, err, "api unavailable")
+	})
+}
+
+func TestGetPodsByLabels(t *testing.T) {
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "broker"},
+		},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-2",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "other"},
+		},
+	}
+	client := fake.NewSimpleClientset(pod1, pod2)
+
+	pods, err := GetPodsByLabels(context.Background(), client, "default", map[string]string{"app": "broker"})
+	require.NoError(t, err)
+	require.Len(t, pods.Items, 1)
+	require.Equal(t, "pod-1", pods.Items[0].Name)
+}
+
+func TestGetDaemonSetPods(t *testing.T) {
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "broker", Namespace: "default"},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "broker"},
+			},
+		},
+	}
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "broker-node-1",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "broker"},
+		},
+		Spec: corev1.PodSpec{NodeName: "node-1"},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "broker-node-2",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "broker"},
+		},
+		Spec: corev1.PodSpec{NodeName: "node-2"},
+	}
+	client := fake.NewSimpleClientset(ds, pod1, pod2)
+
+	t.Run("all pods without node filter", func(t *testing.T) {
+		pods, err := GetDaemonSetPods(context.Background(), client, "broker", "default", "")
+		require.NoError(t, err)
+		require.Len(t, pods.Items, 2)
+	})
+
+	t.Run("daemonset not found returns error", func(t *testing.T) {
+		_, err := GetDaemonSetPods(context.Background(), client, "nonexistent", "default", "")
+		require.Error(t, err)
+	})
+
+	t.Run("nodename filter is applied", func(t *testing.T) {
+		pods, err := GetDaemonSetPods(context.Background(), client, "broker", "default", "node-1")
+		require.NoError(t, err)
+		// fake client doesn't enforce field selectors server-side, but the call succeeds
+		require.NotNil(t, pods)
+	})
+}
+
+func TestGetComputeInstances(t *testing.T) {
+	t.Run("nodes with both annotations are grouped by region", func(t *testing.T) {
+		nodes := &corev1.NodeList{
+			Items: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Annotations: map[string]string{
+							topology.KeyNodeInstance: "i-001",
+							topology.KeyNodeRegion:   "us-east-1",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-2",
+						Annotations: map[string]string{
+							topology.KeyNodeInstance: "i-002",
+							topology.KeyNodeRegion:   "us-east-1",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-3",
+						Annotations: map[string]string{
+							topology.KeyNodeInstance: "i-003",
+							topology.KeyNodeRegion:   "us-west-2",
+						},
+					},
+				},
+			},
+		}
+		cis := GetComputeInstances(nodes)
+		require.Len(t, cis, 2)
+		// collect instances by region for order-independent assertion
+		byRegion := make(map[string]map[string]string)
+		for _, ci := range cis {
+			byRegion[ci.Region] = ci.Instances
+		}
+		require.Equal(t, map[string]string{"i-001": "node-1", "i-002": "node-2"}, byRegion["us-east-1"])
+		require.Equal(t, map[string]string{"i-003": "node-3"}, byRegion["us-west-2"])
+	})
+
+	t.Run("node missing instance annotation is skipped", func(t *testing.T) {
+		nodes := &corev1.NodeList{
+			Items: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "node-1",
+						Annotations: map[string]string{topology.KeyNodeRegion: "us-east-1"},
+					},
+				},
+			},
+		}
+		cis := GetComputeInstances(nodes)
+		require.Empty(t, cis)
+	})
+
+	t.Run("node missing region annotation is skipped", func(t *testing.T) {
+		nodes := &corev1.NodeList{
+			Items: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "node-1",
+						Annotations: map[string]string{topology.KeyNodeInstance: "i-001"},
+					},
+				},
+			},
+		}
+		cis := GetComputeInstances(nodes)
+		require.Empty(t, cis)
+	})
+}
 
 func TestIsPodReady(t *testing.T) {
 	testCases := []struct {

--- a/pkg/engines/slurm/slurm_test.go
+++ b/pkg/engines/slurm/slurm_test.go
@@ -11,13 +11,120 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/NVIDIA/topograph/pkg/engines"
 	"github.com/NVIDIA/topograph/pkg/topology"
 	"github.com/NVIDIA/topograph/pkg/translate"
 )
+
+func TestNamedLoader(t *testing.T) {
+	name, loader := NamedLoader()
+	require.Equal(t, NAME, name)
+	require.NotNil(t, loader)
+}
+
+func TestLoader(t *testing.T) {
+	// Loader has no external dependencies — it simply returns a SlurmEngine.
+	// The paths that call scontrol (GetNodeList, getPartitionNodes, reconfigure)
+	// are not tested here because exec.Exec is a free function, not an interface,
+	// and those paths require a running Slurm daemon.
+	eng, httpErr := Loader(context.Background(), engines.Config{})
+	require.Nil(t, httpErr)
+	require.NotNil(t, eng)
+}
+
+func TestSlurmEngineGenerateOutput(t *testing.T) {
+	// SlurmEngine.GenerateOutput delegates to the package-level GenerateOutput.
+	// This test exercises the method receiver path, which TestGenerateOutput
+	// does not reach because it calls the free function directly.
+	ctx := context.TODO()
+	graph, _ := translate.GetTreeTestSet(false)
+	eng := &SlurmEngine{}
+	out, httpErr := eng.GenerateOutput(ctx, graph, nil)
+	require.Nil(t, httpErr)
+	require.NotEmpty(t, out)
+}
+
+func TestGenerateOutputParamsFilePath(t *testing.T) {
+	ctx := context.TODO()
+	graph, _ := translate.GetTreeTestSet(false)
+	path := filepath.Join(t.TempDir(), "topology.conf")
+	params := &Params{
+		BaseParams:     BaseParams{Plugin: topology.TopologyTree},
+		TopoConfigPath: path,
+		// Reconfigure: false — reconfigure calls exec.Exec("scontrol", "reconfigure")
+		// which requires a running Slurm daemon and is not interface-injectable.
+	}
+
+	out, httpErr := GenerateOutputParams(ctx, graph, params)
+
+	require.Nil(t, httpErr)
+	require.Equal(t, "OK\n", string(out))
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(data), fmt.Sprintf(TopologyHeader, topology.TopologyTree))
+	require.Contains(t, string(data), "SwitchName=")
+}
+
+func TestResolveComputeInstances(t *testing.T) {
+	ctx := context.Background()
+	eng := &SlurmEngine{}
+
+	t.Run("instances already provided — early return", func(t *testing.T) {
+		existing := []topology.ComputeInstances{{Region: "r1", Instances: map[string]string{"i1": "n1"}}}
+		out, httpErr := eng.ResolveComputeInstances(ctx, existing, nil)
+		require.Nil(t, httpErr)
+		require.Equal(t, existing, out)
+	})
+
+	t.Run("environment does not implement instanceMapper", func(t *testing.T) {
+		out, httpErr := eng.ResolveComputeInstances(ctx, nil, "not-an-instancemapper")
+		require.Nil(t, out)
+		require.NotNil(t, httpErr)
+		require.Equal(t, http.StatusBadRequest, httpErr.Code())
+		require.ErrorContains(t, httpErr, "environment must implement instanceMapper")
+	})
+
+	// The path through GetNodeList is not tested here: GetNodeList calls
+	// exec.Exec("scontrol", "show", "nodes", ...) which is a free function
+	// (not interface-injectable) and requires a running Slurm daemon.
+}
+
+func TestGetPartitionNodes(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty partition name returns error", func(t *testing.T) {
+		finder := &TopologyNodeFinder{
+			GetPartitionNodes: func(context.Context, string, []any) (string, error) {
+				return "", nil
+			},
+		}
+		_, err := GetPartitionNodes(ctx, "", finder)
+		require.EqualError(t, err, "missing partition name")
+	})
+
+	t.Run("injectable finder — valid fixture output", func(t *testing.T) {
+		fixture := `PartitionName=my_partition
+   Nodes=node[001-004]
+`
+		finder := &TopologyNodeFinder{
+			GetPartitionNodes: func(_ context.Context, _ string, _ []any) (string, error) {
+				return fixture, nil
+			},
+		}
+		nodes, err := GetPartitionNodes(ctx, "my_partition", finder)
+		require.NoError(t, err)
+		require.Equal(t, []string{"node[001-004]"}, nodes)
+	})
+
+	// getPartitionNodes (the concrete implementation used in production) calls
+	// exec.Exec("scontrol", ...) and is not testable without a running Slurm daemon.
+}
 
 func TestAggregateComputeInstances(t *testing.T) {
 	testCases := []struct {

--- a/pkg/engines/slurm/slurm_test.go
+++ b/pkg/engines/slurm/slurm_test.go
@@ -26,6 +26,9 @@ func TestNamedLoader(t *testing.T) {
 	name, loader := NamedLoader()
 	require.Equal(t, NAME, name)
 	require.NotNil(t, loader)
+	eng, httpErr := loader(context.Background(), engines.Config{})
+	require.Nil(t, httpErr)
+	require.IsType(t, &SlurmEngine{}, eng)
 }
 
 func TestLoader(t *testing.T) {
@@ -35,7 +38,7 @@ func TestLoader(t *testing.T) {
 	// and those paths require a running Slurm daemon.
 	eng, httpErr := Loader(context.Background(), engines.Config{})
 	require.Nil(t, httpErr)
-	require.NotNil(t, eng)
+	require.IsType(t, &SlurmEngine{}, eng)
 }
 
 func TestSlurmEngineGenerateOutput(t *testing.T) {
@@ -53,22 +56,35 @@ func TestSlurmEngineGenerateOutput(t *testing.T) {
 func TestGenerateOutputParamsFilePath(t *testing.T) {
 	ctx := context.TODO()
 	graph, _ := translate.GetTreeTestSet(false)
-	path := filepath.Join(t.TempDir(), "topology.conf")
-	params := &Params{
-		BaseParams:     BaseParams{Plugin: topology.TopologyTree},
-		TopoConfigPath: path,
-		// Reconfigure: false — reconfigure calls exec.Exec("scontrol", "reconfigure")
-		// which requires a running Slurm daemon and is not interface-injectable.
-	}
 
-	out, httpErr := GenerateOutputParams(ctx, graph, params)
+	t.Run("success — file written and OK returned", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "topology.conf")
+		params := &Params{
+			BaseParams:     BaseParams{Plugin: topology.TopologyTree},
+			TopoConfigPath: path,
+			// Reconfigure: false — reconfigure calls exec.Exec("scontrol", "reconfigure")
+			// which requires a running Slurm daemon and is not interface-injectable.
+		}
+		out, httpErr := GenerateOutputParams(ctx, graph, params)
+		require.Nil(t, httpErr)
+		require.Equal(t, "OK\n", string(out))
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Contains(t, string(data), fmt.Sprintf(TopologyHeader, topology.TopologyTree))
+		require.Contains(t, string(data), "SwitchName=")
+	})
 
-	require.Nil(t, httpErr)
-	require.Equal(t, "OK\n", string(out))
-	data, err := os.ReadFile(path)
-	require.NoError(t, err)
-	require.Contains(t, string(data), fmt.Sprintf(TopologyHeader, topology.TopologyTree))
-	require.Contains(t, string(data), "SwitchName=")
+	t.Run("file creation failure returns InternalServerError", func(t *testing.T) {
+		// Use a path whose parent directory does not exist to force a write failure.
+		failPath := filepath.Join(t.TempDir(), "nonexistent-subdir", "topology.conf")
+		params := &Params{
+			BaseParams:     BaseParams{Plugin: topology.TopologyTree},
+			TopoConfigPath: failPath,
+		}
+		_, httpErr := GenerateOutputParams(ctx, graph, params)
+		require.NotNil(t, httpErr)
+		require.Equal(t, http.StatusInternalServerError, httpErr.Code())
+	})
 }
 
 func TestResolveComputeInstances(t *testing.T) {
@@ -98,27 +114,44 @@ func TestResolveComputeInstances(t *testing.T) {
 func TestGetPartitionNodes(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("empty partition name returns error", func(t *testing.T) {
+	t.Run("empty partition name returns error without invoking finder", func(t *testing.T) {
+		called := false
 		finder := &TopologyNodeFinder{
 			GetPartitionNodes: func(context.Context, string, []any) (string, error) {
+				called = true
 				return "", nil
 			},
 		}
 		_, err := GetPartitionNodes(ctx, "", finder)
 		require.EqualError(t, err, "missing partition name")
+		require.False(t, called, "finder must not be invoked when partition name is empty")
 	})
 
-	t.Run("injectable finder — valid fixture output", func(t *testing.T) {
+	t.Run("finder error is propagated", func(t *testing.T) {
+		finder := &TopologyNodeFinder{
+			GetPartitionNodes: func(_ context.Context, partition string, _ []any) (string, error) {
+				require.Equal(t, "my_partition", partition)
+				return "", fmt.Errorf("scontrol failed")
+			},
+		}
+		_, err := GetPartitionNodes(ctx, "my_partition", finder)
+		require.ErrorContains(t, err, "scontrol failed")
+	})
+
+	t.Run("injectable finder — partition name forwarded and result parsed", func(t *testing.T) {
 		fixture := `PartitionName=my_partition
    Nodes=node[001-004]
 `
+		var receivedPartition string
 		finder := &TopologyNodeFinder{
-			GetPartitionNodes: func(_ context.Context, _ string, _ []any) (string, error) {
+			GetPartitionNodes: func(_ context.Context, partition string, _ []any) (string, error) {
+				receivedPartition = partition
 				return fixture, nil
 			},
 		}
 		nodes, err := GetPartitionNodes(ctx, "my_partition", finder)
 		require.NoError(t, err)
+		require.Equal(t, "my_partition", receivedPartition)
 		require.Equal(t, []string{"node[001-004]"}, nodes)
 	})
 

--- a/pkg/engines/slurm/slurm_test.go
+++ b/pkg/engines/slurm/slurm_test.go
@@ -28,6 +28,7 @@ func TestNamedLoader(t *testing.T) {
 	require.NotNil(t, loader)
 	eng, httpErr := loader(context.Background(), engines.Config{})
 	require.Nil(t, httpErr)
+	require.NotNil(t, eng)
 	require.IsType(t, &SlurmEngine{}, eng)
 }
 
@@ -38,6 +39,7 @@ func TestLoader(t *testing.T) {
 	// and those paths require a running Slurm daemon.
 	eng, httpErr := Loader(context.Background(), engines.Config{})
 	require.Nil(t, httpErr)
+	require.NotNil(t, eng)
 	require.IsType(t, &SlurmEngine{}, eng)
 }
 
@@ -138,21 +140,40 @@ func TestGetPartitionNodes(t *testing.T) {
 		require.ErrorContains(t, err, "scontrol failed")
 	})
 
-	t.Run("injectable finder — partition name forwarded and result parsed", func(t *testing.T) {
+	t.Run("injectable finder — partition name and context forwarded, result parsed", func(t *testing.T) {
 		fixture := `PartitionName=my_partition
    Nodes=node[001-004]
 `
+		testCtx := context.WithValue(ctx, struct{ key string }{"k"}, "v")
+		var receivedCtx context.Context
 		var receivedPartition string
 		finder := &TopologyNodeFinder{
-			GetPartitionNodes: func(_ context.Context, partition string, _ []any) (string, error) {
+			GetPartitionNodes: func(c context.Context, partition string, _ []any) (string, error) {
+				receivedCtx = c
 				receivedPartition = partition
 				return fixture, nil
 			},
 		}
-		nodes, err := GetPartitionNodes(ctx, "my_partition", finder)
+		nodes, err := GetPartitionNodes(testCtx, "my_partition", finder)
 		require.NoError(t, err)
+		require.Equal(t, testCtx, receivedCtx)
 		require.Equal(t, "my_partition", receivedPartition)
 		require.Equal(t, []string{"node[001-004]"}, nodes)
+	})
+
+	t.Run("canceled context is forwarded to finder and error propagates", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		var receivedCtx context.Context
+		finder := &TopologyNodeFinder{
+			GetPartitionNodes: func(c context.Context, _ string, _ []any) (string, error) {
+				receivedCtx = c
+				return "", c.Err()
+			},
+		}
+		_, err := GetPartitionNodes(cancelCtx, "my_partition", finder)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, cancelCtx, receivedCtx)
 	})
 
 	// getPartitionNodes (the concrete implementation used in production) calls

--- a/pkg/node_observer/main_test.go
+++ b/pkg/node_observer/main_test.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package node_observer
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	// IgnoreCurrent captures goroutines running before m.Run() (klog flushDaemon,
+	// client-go SharedIndexInformer goroutines initialized at import time).
+	//
+	// The workqueue delayingType.waitingLoop filter covers a known async-shutdown
+	// window: tests call informer.Stop() which calls queue.ShutDown(), but
+	// queue.ShutDown() does not synchronously drain the background waitingLoop
+	// goroutine — it only signals it. Goleak fires before the goroutine exits its
+	// final select iteration. This is not a test-scoped resource leak.
+	goleak.VerifyTestMain(m,
+		goleak.IgnoreCurrent(),
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*delayingType[...]).waitingLoop"),
+	)
+}

--- a/pkg/providers/dra/provider_test.go
+++ b/pkg/providers/dra/provider_test.go
@@ -7,6 +7,7 @@ package dra
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/NVIDIA/topograph/pkg/accelerator"
@@ -14,8 +15,44 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
+
+func TestDRANamedLoader(t *testing.T) {
+	name, loader := NamedLoader()
+	require.Equal(t, NAME, name)
+	require.NotNil(t, loader)
+	// Loader itself is not exercised here: it calls rest.InClusterConfig() which
+	// returns an error outside a Kubernetes pod (StatusBadGateway). That path
+	// is not meaningfully testable in a unit environment.
+}
+
+func TestGetNodeAnnotations(t *testing.T) {
+	ann, err := GetNodeAnnotations(context.Background(), "my-node")
+	require.NoError(t, err)
+	require.NotEmpty(t, ann)
+}
+
+func TestGenerateTopologyConfigAPIError(t *testing.T) {
+	errClient := fake.NewSimpleClientset()
+	errClient.PrependReactor("list", "nodes", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("api unavailable")
+	})
+	provider := &Provider{
+		client:           errClient,
+		accelerator:      mustAcceleratorDiscoverer(t, defaultDomainLabel),
+		acceleratorLabel: defaultDomainLabel,
+	}
+
+	graph, httpErr := provider.GenerateTopologyConfig(context.Background(), nil, nil)
+
+	require.Nil(t, graph)
+	require.NotNil(t, httpErr)
+	require.Equal(t, 502, httpErr.Code())
+	require.ErrorContains(t, httpErr, "api unavailable")
+}
 
 func TestNewAcceleratorDiscoverer(t *testing.T) {
 	tests := []struct {

--- a/pkg/providers/dra/provider_test.go
+++ b/pkg/providers/dra/provider_test.go
@@ -8,9 +8,11 @@ package dra
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/NVIDIA/topograph/pkg/accelerator"
+	"github.com/NVIDIA/topograph/pkg/providers"
 	"github.com/NVIDIA/topograph/pkg/topology"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -24,34 +26,63 @@ func TestDRANamedLoader(t *testing.T) {
 	name, loader := NamedLoader()
 	require.Equal(t, NAME, name)
 	require.NotNil(t, loader)
-	// Loader itself is not exercised here: it calls rest.InClusterConfig() which
-	// returns an error outside a Kubernetes pod (StatusBadGateway). That path
-	// is not meaningfully testable in a unit environment.
+	// Exercise a deterministic failure path that does not require rest.InClusterConfig:
+	// an unsupported accelerator source fails at newAcceleratorDiscoverer (400 Bad Request)
+	// before the in-cluster config is read.
+	_, httpErr := loader(context.Background(), providers.Config{
+		Params: map[string]any{"accelerator": map[string]any{"source": accelerator.SourceNone}},
+	})
+	require.NotNil(t, httpErr)
+	require.Equal(t, http.StatusBadRequest, httpErr.Code())
+	require.ErrorContains(t, httpErr, `dra provider supports only accelerator source "kubernetes-label"`)
 }
 
 func TestGetNodeAnnotations(t *testing.T) {
 	ann, err := GetNodeAnnotations(context.Background(), "my-node")
 	require.NoError(t, err)
-	require.NotEmpty(t, ann)
+	require.Equal(t, map[string]string{
+		topology.KeyNodeInstance: "my-node",
+		topology.KeyNodeRegion:   "local",
+	}, ann)
 }
 
 func TestGenerateTopologyConfigAPIError(t *testing.T) {
-	errClient := fake.NewSimpleClientset()
-	errClient.PrependReactor("list", "nodes", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, fmt.Errorf("api unavailable")
+	t.Run("API error is propagated as 502", func(t *testing.T) {
+		errClient := fake.NewSimpleClientset()
+		errClient.PrependReactor("list", "nodes", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("api unavailable")
+		})
+		provider := &Provider{
+			client:           errClient,
+			accelerator:      mustAcceleratorDiscoverer(t, defaultDomainLabel),
+			acceleratorLabel: defaultDomainLabel,
+		}
+		graph, httpErr := provider.GenerateTopologyConfig(context.Background(), nil, nil)
+		require.Nil(t, graph)
+		require.NotNil(t, httpErr)
+		require.Equal(t, 502, httpErr.Code())
+		require.ErrorContains(t, httpErr, "api unavailable")
 	})
-	provider := &Provider{
-		client:           errClient,
-		accelerator:      mustAcceleratorDiscoverer(t, defaultDomainLabel),
-		acceleratorLabel: defaultDomainLabel,
-	}
 
-	graph, httpErr := provider.GenerateTopologyConfig(context.Background(), nil, nil)
-
-	require.Nil(t, graph)
-	require.NotNil(t, httpErr)
-	require.Equal(t, 502, httpErr.Code())
-	require.ErrorContains(t, httpErr, "api unavailable")
+	t.Run("canceled context error is propagated as 502", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		errClient := fake.NewSimpleClientset()
+		errClient.PrependReactor("list", "nodes", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			// cancel context and return its error to simulate caller cancellation
+			cancel()
+			return true, nil, ctx.Err()
+		})
+		provider := &Provider{
+			client:           errClient,
+			accelerator:      mustAcceleratorDiscoverer(t, defaultDomainLabel),
+			acceleratorLabel: defaultDomainLabel,
+		}
+		graph, httpErr := provider.GenerateTopologyConfig(ctx, nil, nil)
+		require.Nil(t, graph)
+		require.NotNil(t, httpErr)
+		require.Equal(t, 502, httpErr.Code())
+		require.ErrorContains(t, httpErr, "context canceled")
+	})
 }
 
 func TestNewAcceleratorDiscoverer(t *testing.T) {

--- a/pkg/providers/infiniband/provider_bm.go
+++ b/pkg/providers/infiniband/provider_bm.go
@@ -19,7 +19,8 @@ import (
 const NAME_BM = "infiniband-bm"
 
 type ProviderBM struct {
-	accelerator accelerator.Discoverer
+	accelerator   accelerator.Discoverer
+	ibNetDiscover IBNetDiscover
 }
 
 func NamedLoaderBM() (string, providers.Loader) {
@@ -35,7 +36,7 @@ func LoaderBM(_ context.Context, providerConfig providers.Config) (providers.Pro
 		return nil, httperr.NewError(http.StatusBadRequest, err.Error())
 	}
 
-	return &ProviderBM{accelerator: discoverer}, nil
+	return &ProviderBM{accelerator: discoverer, ibNetDiscover: &IBNetDiscoverBM{}}, nil
 }
 
 func (p *ProviderBM) GenerateTopologyConfig(ctx context.Context, _ *int, cis []topology.ComputeInstances) (*topology.Graph, *httperr.Error) {
@@ -50,7 +51,7 @@ func (p *ProviderBM) GenerateTopologyConfig(ctx context.Context, _ *int, cis []t
 	}
 	domainMap := accelerator.DomainMapFromAssignments(assignments, targets)
 
-	treeRoot, err := getIbTree(ctx, cis, &IBNetDiscoverBM{})
+	treeRoot, err := getIbTree(ctx, cis, p.ibNetDiscover)
 	if err != nil {
 		return nil, httperr.NewError(http.StatusInternalServerError, fmt.Sprintf("getIbTree failed: %v", err))
 	}

--- a/pkg/providers/infiniband/provider_bm_test.go
+++ b/pkg/providers/infiniband/provider_bm_test.go
@@ -7,13 +7,106 @@ package infiniband
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/topograph/pkg/accelerator"
 	"github.com/NVIDIA/topograph/pkg/providers"
+	"github.com/NVIDIA/topograph/pkg/topology"
 )
+
+func TestProviderBMNamedLoader(t *testing.T) {
+	name, loader := NamedLoaderBM()
+	require.Equal(t, NAME_BM, name)
+	require.NotNil(t, loader)
+}
+
+func TestProviderBMRejectsMultiRegionRequest(t *testing.T) {
+	provider := &ProviderBM{}
+	graph, httpErr := provider.GenerateTopologyConfig(context.Background(), nil, []topology.ComputeInstances{
+		{Region: "region-1"},
+		{Region: "region-2"},
+	})
+
+	require.Nil(t, graph)
+	require.NotNil(t, httpErr)
+	require.Equal(t, http.StatusBadRequest, httpErr.Code())
+	require.ErrorContains(t, httpErr, "on-prem does not support multi-region topology requests")
+}
+
+func TestProviderBMGenerateTopologyConfig(t *testing.T) {
+	// testIBNetDiscover (from common_test.go) reads the real ibnetdiscover fixture
+	// captured from InfiniBand hardware in tests/output/ibnetdiscover/example.out.
+	// IBNetDiscoverBM.Run (exec.Pdsh) is not testable without a running IB cluster;
+	// that path remains at 0% coverage by design — only the transport layer is excluded.
+	cis := []topology.ComputeInstances{
+		{
+			Region: "on-prem",
+			Instances: map[string]string{
+				"b07-p1-dgx-07-c01": "b07-p1-dgx-07-c01",
+				"b07-p1-dgx-07-c02": "b07-p1-dgx-07-c02",
+				"b07-p1-dgx-07-c03": "b07-p1-dgx-07-c03",
+				"b07-p1-dgx-07-c04": "b07-p1-dgx-07-c04",
+			},
+		},
+	}
+
+	t.Run("ibnetdiscover error produces empty tiers — getIbTree treats errors as warnings", func(t *testing.T) {
+		p := &ProviderBM{
+			accelerator:   mustNoneDiscoverer(t),
+			ibNetDiscover: &testIBNetDiscover{err: true},
+		}
+		graph, httpErr := p.GenerateTopologyConfig(context.Background(), nil, cis)
+		require.Nil(t, httpErr)
+		require.NotNil(t, graph)
+		// getIbTree logs a warning on Run errors and returns an empty tree (not an error)
+		require.Empty(t, graph.Tiers.Vertices)
+	})
+
+	t.Run("valid fixture produces graph with tiers", func(t *testing.T) {
+		p := &ProviderBM{
+			accelerator:   mustNoneDiscoverer(t),
+			ibNetDiscover: &testIBNetDiscover{},
+		}
+		graph, httpErr := p.GenerateTopologyConfig(context.Background(), nil, cis)
+		require.Nil(t, httpErr)
+		require.NotNil(t, graph)
+		require.NotNil(t, graph.Tiers)
+		require.NotEmpty(t, graph.Tiers.Vertices)
+	})
+}
+
+func TestProviderBMInstances2NodeMap(t *testing.T) {
+	p := &ProviderBM{}
+	nodes := []string{"node-1", "node-2"}
+	i2n, err := p.Instances2NodeMap(context.Background(), nodes)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"node-1": "node-1", "node-2": "node-2"}, i2n)
+}
+
+func TestProviderBMGetInstancesRegions(t *testing.T) {
+	p := &ProviderBM{}
+	nodes := []string{"node-1", "node-2"}
+	regions, err := p.GetInstancesRegions(context.Background(), nodes)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"node-1": "local", "node-2": "local"}, regions)
+}
+
+// mustNoneDiscoverer returns an accelerator.Discoverer with source=none,
+// so GenerateTopologyConfig tests focus on the IB fabric path.
+func mustNoneDiscoverer(t *testing.T) accelerator.Discoverer {
+	t.Helper()
+	d, err := accelerator.NewCommandDiscoverer(
+		accelerator.SectionFromProviderParams(map[string]any{
+			"accelerator": map[string]any{"source": accelerator.SourceNone},
+		}),
+		nil,
+	)
+	require.NoError(t, err)
+	return d
+}
 
 func TestLoaderBMAcceleratorSource(t *testing.T) {
 	tests := []struct {

--- a/pkg/providers/infiniband/provider_bm_test.go
+++ b/pkg/providers/infiniband/provider_bm_test.go
@@ -21,6 +21,11 @@ func TestProviderBMNamedLoader(t *testing.T) {
 	name, loader := NamedLoaderBM()
 	require.Equal(t, NAME_BM, name)
 	require.NotNil(t, loader)
+	// Invoke loader to verify LoaderBM wires ibNetDiscover (regression for #492).
+	p, httpErr := loader(context.Background(), providers.Config{})
+	require.Nil(t, httpErr)
+	require.IsType(t, &ProviderBM{}, p)
+	require.NotNil(t, p.(*ProviderBM).ibNetDiscover)
 }
 
 func TestProviderBMRejectsMultiRegionRequest(t *testing.T) {
@@ -80,18 +85,48 @@ func TestProviderBMGenerateTopologyConfig(t *testing.T) {
 
 func TestProviderBMInstances2NodeMap(t *testing.T) {
 	p := &ProviderBM{}
-	nodes := []string{"node-1", "node-2"}
-	i2n, err := p.Instances2NodeMap(context.Background(), nodes)
-	require.NoError(t, err)
-	require.Equal(t, map[string]string{"node-1": "node-1", "node-2": "node-2"}, i2n)
+
+	t.Run("identity mapping", func(t *testing.T) {
+		i2n, err := p.Instances2NodeMap(context.Background(), []string{"node-1", "node-2"})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"node-1": "node-1", "node-2": "node-2"}, i2n)
+	})
+
+	t.Run("empty input returns empty map", func(t *testing.T) {
+		i2n, err := p.Instances2NodeMap(context.Background(), nil)
+		require.NoError(t, err)
+		require.Empty(t, i2n)
+	})
+
+	t.Run("duplicate node — idempotent, cardinality matches unique keys", func(t *testing.T) {
+		i2n, err := p.Instances2NodeMap(context.Background(), []string{"node-1", "node-1"})
+		require.NoError(t, err)
+		require.Len(t, i2n, 1)
+		require.Equal(t, "node-1", i2n["node-1"])
+	})
 }
 
 func TestProviderBMGetInstancesRegions(t *testing.T) {
 	p := &ProviderBM{}
-	nodes := []string{"node-1", "node-2"}
-	regions, err := p.GetInstancesRegions(context.Background(), nodes)
-	require.NoError(t, err)
-	require.Equal(t, map[string]string{"node-1": "local", "node-2": "local"}, regions)
+
+	t.Run("all regions are local", func(t *testing.T) {
+		regions, err := p.GetInstancesRegions(context.Background(), []string{"node-1", "node-2"})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"node-1": "local", "node-2": "local"}, regions)
+	})
+
+	t.Run("empty input returns empty map", func(t *testing.T) {
+		regions, err := p.GetInstancesRegions(context.Background(), nil)
+		require.NoError(t, err)
+		require.Empty(t, regions)
+	})
+
+	t.Run("duplicate node — idempotent, cardinality matches unique keys", func(t *testing.T) {
+		regions, err := p.GetInstancesRegions(context.Background(), []string{"node-1", "node-1"})
+		require.NoError(t, err)
+		require.Len(t, regions, 1)
+		require.Equal(t, "local", regions["node-1"])
+	})
 }
 
 // mustNoneDiscoverer returns an accelerator.Discoverer with source=none,

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -35,10 +36,11 @@ import (
 )
 
 type HttpServer struct {
-	ctx   context.Context
-	cfg   *config.Config
-	srv   *http.Server
-	async *asyncController
+	ctx      context.Context
+	cfg      *config.Config
+	srv      *http.Server
+	async    *asyncController
+	stopOnce sync.Once
 }
 
 type asyncController struct {
@@ -126,12 +128,14 @@ func (s *HttpServer) Start() error {
 }
 
 func (s *HttpServer) Stop(err error) {
-	klog.Infof("Stopping HTTP server: %v", err)
-	if err := s.srv.Shutdown(s.ctx); err != nil {
-		klog.Errorf("Error during HTTP server shutdown: %v", err)
-	}
-	s.async.queue.Shutdown()
-	klog.Infof("Stopped HTTP server")
+	s.stopOnce.Do(func() {
+		klog.Infof("Stopping HTTP server: %v", err)
+		if err := s.srv.Shutdown(s.ctx); err != nil {
+			klog.Errorf("Error during HTTP server shutdown: %v", err)
+		}
+		s.async.queue.Shutdown()
+		klog.Infof("Stopped HTTP server")
+	})
 }
 
 func healthz(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/http_server.go
+++ b/pkg/server/http_server.go
@@ -130,6 +130,7 @@ func (s *HttpServer) Stop(err error) {
 	if err := s.srv.Shutdown(s.ctx); err != nil {
 		klog.Errorf("Error during HTTP server shutdown: %v", err)
 	}
+	s.async.queue.Shutdown()
 	klog.Infof("Stopped HTTP server")
 }
 

--- a/pkg/server/http_server_test.go
+++ b/pkg/server/http_server_test.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -683,4 +684,27 @@ func TestReadInvalidRequest(t *testing.T) {
 			readInvalidRequest(t, tc.payload, tc.message)
 		})
 	}
+}
+
+func TestHttpServerStopIdempotent(t *testing.T) {
+	port, err := test.GetAvailablePort()
+	require.NoError(t, err)
+	s := initHttpServer(context.Background(), &config.Config{
+		HTTP: config.Endpoint{Port: port},
+	})
+
+	// sequential repeated calls must not panic
+	s.Stop(nil)
+	s.Stop(nil)
+
+	// concurrent calls must not panic
+	var wg sync.WaitGroup
+	for range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.Stop(nil)
+		}()
+	}
+	wg.Wait()
 }

--- a/pkg/server/integration_test.go
+++ b/pkg/server/integration_test.go
@@ -34,6 +34,12 @@ func TestServerIntegration(t *testing.T) {
 	backOff = 100 * time.Millisecond
 	defer func() { backOff = defaultBackOff }()
 
+	// testIntegration and topologyRequestWithRetries use http.DefaultClient / http.Get,
+	// which pool keep-alive connections in http.DefaultTransport. Close idle connections
+	// after the test so goroutine-leak detectors do not flag the transport's readLoop /
+	// writeLoop goroutines. See https://github.com/NVIDIA/topograph/issues/493.
+	t.Cleanup(func() { http.DefaultClient.CloseIdleConnections() })
+
 	port, err := test.GetAvailablePort()
 	require.NoError(t, err)
 

--- a/pkg/server/integration_test.go
+++ b/pkg/server/integration_test.go
@@ -126,6 +126,7 @@ func testIntegration(t *testing.T, baseURL, payload, expected, generateMethod st
 	// send generate request and validate response code
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
+	defer resp.Body.Close()
 	require.Equal(t, tp.Provider.Params.GenerateResponseCode, resp.StatusCode)
 	if resp.StatusCode != http.StatusAccepted {
 		return
@@ -134,7 +135,6 @@ func testIntegration(t *testing.T, baseURL, payload, expected, generateMethod st
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	out := string(body)
-	resp.Body.Close()
 
 	// retrieve topology config
 	params := url.Values{}

--- a/pkg/server/main_test.go
+++ b/pkg/server/main_test.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package server
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	// IgnoreCurrent captures goroutines running before m.Run() (klog flushDaemon)
+	// so they do not trigger false positives.
+	//
+	// Integration tests make HTTP requests via http.DefaultTransport but do not
+	// call CloseIdleConnections() on teardown, leaving keep-alive connection
+	// goroutines in the transport pool. Tracked in
+	// https://github.com/NVIDIA/topograph/issues/493; filter until fixed.
+	goleak.VerifyTestMain(m,
+		goleak.IgnoreCurrent(),
+		goleak.IgnoreTopFunction("net/http.(*persistConn).readLoop"),
+		goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
+	)
+}

--- a/pkg/server/main_test.go
+++ b/pkg/server/main_test.go
@@ -15,10 +15,12 @@ func TestMain(m *testing.M) {
 	// IgnoreCurrent captures goroutines running before m.Run() (klog flushDaemon)
 	// so they do not trigger false positives.
 	//
-	// Integration tests make HTTP requests via http.DefaultTransport but do not
-	// call CloseIdleConnections() on teardown, leaving keep-alive connection
-	// goroutines in the transport pool. Tracked in
-	// https://github.com/NVIDIA/topograph/issues/493; filter until fixed.
+	// TestServerIntegration calls http.DefaultClient.CloseIdleConnections() in its
+	// t.Cleanup, which signals the transport to close keep-alive connections.
+	// However, persistConn goroutines do not exit synchronously — they drain their
+	// final select iteration after the close signal. Goleak fires in that async
+	// window, so the filters below remain necessary even with CloseIdleConnections().
+	// Tracked in https://github.com/NVIDIA/topograph/issues/493.
 	goleak.VerifyTestMain(m,
 		goleak.IgnoreCurrent(),
 		goleak.IgnoreTopFunction("net/http.(*persistConn).readLoop"),


### PR DESCRIPTION
## Description

Expands test coverage across five packages, adds goroutine-leak detection via `go.uber.org/goleak`, and fixes one production bug revealed by goleak.

### Commits

**1. `test(internal/k8s)`: GetNodes, GetPodsByLabels, GetDaemonSetPods, GetComputeInstances** (original)

Uses `fake.NewSimpleClientset()` and `client.Actions()` inspection — the standard approach for testing client-go wrappers without a real cluster. `ExecInPod` remains at 0%: it dials a real SPDY connection via `remotecommand.NewSPDYExecutor`; not testable with the fake client.

**2. `test(internal/k8s)`: address review feedback on selector and coverage assertions**

Adds `ClearActions()` + `Actions()` inspection to `TestGetDaemonSetPods` to verify label/field selectors are sent correctly (the fake client doesn't enforce them server-side), and adds a mixed valid+incomplete nodes subtest to `TestGetComputeInstances`.

**3. `test`: slurm engine, dra provider, goleak, and HttpServer.Stop() fix**

- `pkg/engines/slurm`: `NamedLoader`, `Loader`, `SlurmEngine.GenerateOutput` method (previously the free function was tested but not the method receiver), `GenerateOutputParams` with a file-path destination (using `t.TempDir()`), `ResolveComputeInstances` early-return and missing-instanceMapper error paths, and `GetPartitionNodes` with an injectable `TopologyNodeFinder`. Paths that call `exec.Exec("scontrol")` are not tested — `exec.Exec` is a free function, not interface-injectable, and requires a running Slurm daemon.
- `pkg/providers/dra`: `NamedLoader`, `GetNodeAnnotations`, and the `k8s.GetNodes` API-error path via `PrependReactor`. `Loader` is not tested — it calls `rest.InClusterConfig()` which fails outside a Kubernetes pod.
- `pkg/server` + `pkg/node_observer`: `TestMain` with `goleak.VerifyTestMain`. Goleak revealed that `HttpServer.Stop()` did not call `s.async.queue.Shutdown()`, leaving the `TrailingDelayQueue.run` goroutine alive after server stop — **fixed in this commit** (pre-existing production bug, tracked in #495). HTTP idle-connection goroutines from integration tests are filtered pending #493 / #494.
- `pkg/node_observer`: `client-go` workqueue `waitingLoop` goroutines from `queue.ShutDown()` are async; filtered with a documented `IgnoreTopFunction` filter (standard brownfield goleak pattern).

**4. `test(provider/infiniband)`: ProviderBM composition layer**

Adds `IBNetDiscover` as an injectable field on `ProviderBM` (wired to `&IBNetDiscoverBM{}` in `LoaderBM`), enabling tests of the composition layer using the `testIBNetDiscover` fixture from `common_test.go` — which reads real `ibnetdiscover -N` output captured from InfiniBand hardware in `tests/output/ibnetdiscover/example.out`. `IBNetDiscoverBM.Run` (calls `exec.Pdsh("sudo ibnetdiscover")`) and `IBNetDiscoverK8S.Run` (SPDY exec) remain at 0% — transport layer, not testable without live hardware.

### Coverage delta (approximate)

| Package | Before | After |
|---|---|---|
| `internal/k8s` | 44.8% | 79.0% |
| `pkg/engines/slurm` | 56.3% | ~72% |
| `pkg/providers/dra` | 77.8% | ~89% |
| `pkg/providers/infiniband` | varies | +ProviderBM composition |
| `pkg/server` | 92.5% | 92.5% + leak detection |
| `pkg/node_observer` | 69% | 69% + leak detection |

### Related

- closes #495 (`HttpServer.Stop()` queue shutdown — pre-existing bug)
- References #493 / #494 (HTTP idle-connection cleanup, pending)

## Checklist

- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] Documentation impact evaluated — no doc changes needed (test-only + internal bug fix).
- [x] User-facing changes recorded in `CHANGELOG.md` — tests only; production fix is `HttpServer.Stop()` queue shutdown (not user-visible behavior change).
- [ ] `pkg/topology/` changes were discussed in an issue first — N/A
- [x] Every commit has a DCO sign-off.