### PR TITLE
test(server): remove persistConn goleak filters, closes #493

### DIFF
--- a/pkg/server/main_test.go
+++ b/pkg/server/main_test.go
@@ -14,16 +14,5 @@ import (
 func TestMain(m *testing.M) {
 	// IgnoreCurrent captures goroutines running before m.Run() (klog flushDaemon)
 	// so they do not trigger false positives.
-	//
-	// TestServerIntegration calls http.DefaultClient.CloseIdleConnections() in its
-	// t.Cleanup, which signals the transport to close keep-alive connections.
-	// However, persistConn goroutines do not exit synchronously — they drain their
-	// final select iteration after the close signal. Goleak fires in that async
-	// window, so the filters below remain necessary even with CloseIdleConnections().
-	// Tracked in https://github.com/NVIDIA/topograph/issues/493.
-	goleak.VerifyTestMain(m,
-		goleak.IgnoreCurrent(),
-		goleak.IgnoreTopFunction("net/http.(*persistConn).readLoop"),
-		goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
-	)
+	goleak.VerifyTestMain(m, goleak.IgnoreCurrent())
 }


### PR DESCRIPTION
## Description

`pkg/server/main_test.go` carried two `goleak.IgnoreTopFunction` filters for `net/http.(*persistConn).readLoop` and `.writeLoop`, added in #492 as a temporary workaround pending a proper fix for #493.

The fix (`t.Cleanup(func() { http.DefaultClient.CloseIdleConnections() })` in `TestServerIntegration`) landed in #492. Tests pass locally without the filters, confirming `CloseIdleConnections()` is sufficient — persistConn goroutines exit before goleak's check fires.

This PR removes the two filters and the explanatory comment, leaving only `goleak.IgnoreCurrent()` (which suppresses pre-existing goroutines like klog's `flushDaemon`).

Closes #493

## Checklist

- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] Documentation impact evaluated — no doc changes needed.
- [x] User-facing changes recorded in `CHANGELOG.md` — tests only.
- [ ] `pkg/topology/` changes were discussed in an issue first — N/A
- [x] Every commit has a DCO sign-off.