### PR TITLE
fix(node-observer): request topology regeneration for unrecoverable tombstones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `Go` workflow now also runs on pushes to `main`, so Codecov receives a coverage report for every merged commit. Merges are squashed, so the SHA that lands on `main` no longer matches the `pull-request/<n>` SHA that uploaded coverage; without a `main` trigger, Codecov's `main` branch had gone stale since 2026-07-06 and the README coverage badge reported a figure roughly six points below actual coverage.
 - GCP and OCI simulation providers now handle partial final pagination pages without indexing past the available instances.
 - Non-positive `pageSize` configuration values now emit a warning and use the provider default instead of reaching provider APIs and simulation pagination loops.
+- The node observer now regenerates topology for every deletion its informers report. Deletions that happen while a watch is disconnected arrive as `cache.DeletedFinalStateUnknown` tombstones, which carry a nil object when the resource has already left the informer store. The node, pod, API server, and node-data-broker delete handlers all required the tombstone to unwrap to the watched type, so those deletions were dropped and the topology stayed stale until an unrelated event arrived.
 
 ### Security
 

--- a/pkg/node_observer/status_informer.go
+++ b/pkg/node_observer/status_informer.go
@@ -188,6 +188,17 @@ func (s *StatusInformer) Stop(_ error) {
 	})
 }
 
+func (s *StatusInformer) requestOnDelete(kind string) func(any) {
+	return func(obj any) {
+		if key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj); err != nil {
+			klog.V(4).Infof("Informer deleted %s with unidentifiable object: %v", kind, err)
+		} else {
+			klog.V(4).Infof("Informer deleted %s %s", kind, key)
+		}
+		s.sendRequest()
+	}
+}
+
 func (s *StatusInformer) startNodeInformer() error {
 	if s.nodeFactory != nil {
 		informer := s.nodeFactory.Core().V1().Nodes().Informer()
@@ -198,18 +209,7 @@ func (s *StatusInformer) startNodeInformer() error {
 					s.sendRequest()
 				}
 			},
-			DeleteFunc: func(obj any) {
-				switch v := obj.(type) {
-				case *corev1.Node:
-					klog.V(4).Infof("Informer deleted node %s", v.Name)
-					s.sendRequest()
-				case cache.DeletedFinalStateUnknown:
-					if node, ok := v.Obj.(*corev1.Node); ok {
-						klog.V(4).Infof("Informer deleted node %s", node.Name)
-						s.sendRequest()
-					}
-				}
-			},
+			DeleteFunc: s.requestOnDelete("node"),
 		})
 		if err != nil {
 			return err
@@ -250,7 +250,7 @@ func (s *StatusInformer) startAPIServerInformer() error {
 					s.sendRequest()
 				}
 			},
-			DeleteFunc: s.requestOnAPIServerDelete,
+			DeleteFunc: s.requestOnDelete("API server pod"),
 		})
 		if err != nil {
 			return err
@@ -261,19 +261,6 @@ func (s *StatusInformer) startAPIServerInformer() error {
 		}
 	}
 	return nil
-}
-
-func (s *StatusInformer) requestOnAPIServerDelete(obj any) {
-	switch pod := obj.(type) {
-	case *corev1.Pod:
-		klog.V(4).Infof("Informer deleted API server pod %s/%s", pod.Namespace, pod.Name)
-		s.sendRequest()
-	case cache.DeletedFinalStateUnknown:
-		if pod, ok := pod.Obj.(*corev1.Pod); ok {
-			klog.V(4).Infof("Informer deleted API server pod %s/%s", pod.Namespace, pod.Name)
-			s.sendRequest()
-		}
-	}
 }
 
 func (s *StatusInformer) startBrokerInformer() error {
@@ -303,18 +290,7 @@ func (s *StatusInformer) startBrokerInformer() error {
 					s.sendRequest()
 				}
 			},
-			DeleteFunc: func(obj any) {
-				switch v := obj.(type) {
-				case *appsv1.DaemonSet:
-					klog.V(4).Infof("Informer deleted node-data-broker DaemonSet %s/%s", v.Namespace, v.Name)
-					s.sendRequest()
-				case cache.DeletedFinalStateUnknown:
-					if daemonSet, ok := v.Obj.(*appsv1.DaemonSet); ok {
-						klog.V(4).Infof("Informer deleted node-data-broker DaemonSet %s/%s", daemonSet.Namespace, daemonSet.Name)
-						s.sendRequest()
-					}
-				}
-			},
+			DeleteFunc: s.requestOnDelete("node-data-broker DaemonSet"),
 		})
 		if err != nil {
 			return err
@@ -353,18 +329,7 @@ func (s *StatusInformer) startPodInformer() error {
 					s.sendRequest()
 				}
 			},
-			DeleteFunc: func(obj any) {
-				switch v := obj.(type) {
-				case *corev1.Pod:
-					klog.V(4).Infof("Informer deleted pod %s/%s", v.Namespace, v.Name)
-					s.sendRequest()
-				case cache.DeletedFinalStateUnknown:
-					if pod, ok := v.Obj.(*corev1.Pod); ok {
-						klog.V(4).Infof("Informer deleted pod %s/%s", pod.Namespace, pod.Name)
-						s.sendRequest()
-					}
-				}
-			},
+			DeleteFunc: s.requestOnDelete("pod"),
 		})
 		if err != nil {
 			return err

--- a/pkg/node_observer/status_informer.go
+++ b/pkg/node_observer/status_informer.go
@@ -188,6 +188,8 @@ func (s *StatusInformer) Stop(_ error) {
 	})
 }
 
+// requestOnDelete returns a delete handler for the named resource. A relist
+// tombstone can carry a nil object, so the request must not depend on it.
 func (s *StatusInformer) requestOnDelete(kind string) func(any) {
 	return func(obj any) {
 		if key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj); err != nil {

--- a/pkg/node_observer/status_informer_test.go
+++ b/pkg/node_observer/status_informer_test.go
@@ -220,17 +220,15 @@ func TestAPIServerPodReadinessRequiresTargetContainer(t *testing.T) {
 	))
 }
 
-func TestAPIServerPodDeleteQueuesRequest(t *testing.T) {
+func TestRequestOnDeleteQueuesRequest(t *testing.T) {
 	pod := makeWorkloadPod(true, makeContainerStatus("topograph", true, 0))
 	testCases := []struct {
-		name   string
-		obj    any
-		queued bool
+		name string
+		obj  any
 	}{
 		{
-			name:   "pod",
-			obj:    pod,
-			queued: true,
+			name: "pod",
+			obj:  pod,
 		},
 		{
 			name: "tombstone containing pod",
@@ -238,7 +236,12 @@ func TestAPIServerPodDeleteQueuesRequest(t *testing.T) {
 				Key: "topograph/api-server",
 				Obj: pod,
 			},
-			queued: true,
+		},
+		{
+			name: "tombstone without an object",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "topograph/api-server",
+			},
 		},
 		{
 			name: "tombstone containing unexpected object",
@@ -246,7 +249,10 @@ func TestAPIServerPodDeleteQueuesRequest(t *testing.T) {
 				Key: "topograph/api-server",
 				Obj: &appsv1.DaemonSet{},
 			},
-			queued: false,
+		},
+		{
+			name: "object with no resolvable key",
+			obj:  "unexpected",
 		},
 	}
 
@@ -254,13 +260,9 @@ func TestAPIServerPodDeleteQueuesRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newTestStatusInformer(t, time.Second, nil)
 
-			s.requestOnAPIServerDelete(tc.obj)
+			s.requestOnDelete("API server pod")(tc.obj)
 
-			if tc.queued {
-				require.Equal(t, 1, s.queue.Len())
-			} else {
-				require.Zero(t, s.queue.Len())
-			}
+			require.Equal(t, 1, s.queue.Len())
 		})
 	}
 }

--- a/pkg/node_observer/status_informer_test.go
+++ b/pkg/node_observer/status_informer_test.go
@@ -300,6 +300,77 @@ func TestAPIServerInformerRegistersDeleteHandler(t *testing.T) {
 	require.Eventually(t, func() bool { return s.queue.Len() == 1 }, time.Second, 10*time.Millisecond)
 }
 
+func TestBrokerInformerRegistersDeleteHandler(t *testing.T) {
+	daemonSet := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
+		Name:      "topograph-node-data-broker",
+		Namespace: "topograph",
+	}}
+	client := k8sfake.NewSimpleClientset(daemonSet)
+	s, err := NewStatusInformer(
+		context.Background(),
+		client,
+		nil,
+		nil,
+		daemonSet.Name,
+		daemonSet.Namespace,
+		0,
+		nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		s.Stop(nil)
+	})
+
+	require.NoError(t, s.startBrokerInformer())
+
+	// The initial list delivers an add, so drain it before asserting on the delete.
+	require.Eventually(t, func() bool { return s.queue.Len() == 1 }, time.Second, 10*time.Millisecond)
+	key, shutdown := s.queue.Get()
+	require.False(t, shutdown)
+	s.queue.Done(key)
+	s.queue.Forget(key)
+	require.Zero(t, s.queue.Len())
+
+	require.NoError(t, client.AppsV1().DaemonSets(daemonSet.Namespace).Delete(
+		context.Background(),
+		daemonSet.Name,
+		metav1.DeleteOptions{},
+	))
+
+	require.Eventually(t, func() bool { return s.queue.Len() == 1 }, time.Second, 10*time.Millisecond)
+}
+
+func TestPodInformerRegistersDeleteHandler(t *testing.T) {
+	// An unready pod keeps the initial add from queueing a request of its own.
+	pod := makeWorkloadPod(false, makeContainerStatus("topograph", false, 0))
+	client := k8sfake.NewSimpleClientset(pod)
+	s, err := NewStatusInformer(
+		context.Background(),
+		client,
+		&Trigger{PodSelector: &metav1.LabelSelector{}},
+		nil,
+		"",
+		"",
+		0,
+		nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		s.Stop(nil)
+	})
+
+	require.NoError(t, s.startPodInformer())
+	require.Zero(t, s.queue.Len())
+
+	require.NoError(t, client.CoreV1().Pods(pod.Namespace).Delete(
+		context.Background(),
+		pod.Name,
+		metav1.DeleteOptions{},
+	))
+
+	require.Eventually(t, func() bool { return s.queue.Len() == 1 }, time.Second, 10*time.Millisecond)
+}
+
 func reqExecFunc(f httpreq.RequestFunc, _ bool) ([]byte, *httperr.Error) {
 	if _, err := f(); err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

The node observer drops deletions that arrive while a watch is disconnected, leaving the generated topology stale until an unrelated event happens to arrive.

When an informer's watch breaks and it relists, deletions it missed are reported as `cache.DeletedFinalStateUnknown` tombstones. client-go fills in the wrapped object on a best-effort basis only: in `Replace` (`tools/cache/delta_fifo.go`, client-go v0.35.4, the version this repo pins), it sets `Obj` to nil when the known-objects lookup returns an error or the key is no longer in the store, and enqueues the tombstone anyway. The `Key` field is always populated; `Obj` is not.

This replaces the four duplicated type switches with a single handler that resolves the name via `cache.DeletionHandlingMetaNamespaceKeyFunc`, which reads `Key` rather than `Obj`, and requests regeneration unconditionally. The deleted object was only ever read for a log line.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).