### PR TITLE
ci: prune stale untagged container images

### DIFF
--- a/.github/workflows/cleanup-untagged-images.yml
+++ b/.github/workflows/cleanup-untagged-images.yml
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Cleanup Untagged Container Images
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Only show the images that would be deleted'
+        required: true
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      cut_off:
+        description: 'Delete images older than this (for example, 1d, 7d, or 30d)'
+        required: true
+        default: '30d'
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  cleanup-untagged-images:
+    name: Cleanup Untagged Images
+    if: github.repository == 'NVIDIA/topograph'
+    runs-on: linux-amd64-cpu32
+    timeout-minutes: 30
+
+    steps:
+      - name: Delete stale untagged images
+        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb # v3.0.1
+        with:
+          account: NVIDIA
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: topograph
+          cut-off: ${{ github.event.inputs.cut_off || '30d' }}
+          keep-n-most-recent: 5
+          dry-run: ${{ github.event.inputs.dry_run || 'false' }}
+          tag-selection: untagged
+          timestamp-to-use: updated_at


### PR DESCRIPTION
Add a scheduled workflow to prune stale container images from the registry.