### PR TITLE
ci(release): automate GitHub release publication

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -111,8 +111,9 @@ Coverage checks run on pull requests. A drop below target with no matching uplif
 
 - `.github/workflows/go.yml` — build, test, lint, and `govulncheck` on every push and PR
 - `.github/workflows/chart-test.yaml` — Helm chart lint + helm-unittest suites (`make chart-test`) on every push and PR
-- `.github/workflows/docker.yml` — container image build (manual trigger)
-- `.github/workflows/helm-release.yaml` — Helm chart release (manual trigger)
+- `.github/workflows/docker.yml` — container image build on release tags or manual trigger
+- `.github/workflows/helm-release.yaml` — Helm chart release-candidate publication (manual trigger)
+- `.github/workflows/release.yml` — official tag-driven Helm, checksum, and GitHub Release publication
 
 ### Deployment surfaces
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,11 @@ name: Docker
 # separate terms of service, privacy policy, and support
 # documentation.
 
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -24,14 +28,50 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.1
         with:
           persist-credentials: false
+
+      - name: Validate manual branch
+        if: github.event_name == 'workflow_dispatch' && github.ref_type == 'branch'
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "${BRANCH_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Branch ${BRANCH_NAME} conflicts with the official release tag namespace."
+            echo "::error::Publish official releases by pushing the matching Git tag instead."
+            exit 1
+          fi
+
+      - name: Validate release tag
+        if: github.ref_type == 'tag'
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must match vX.Y.Z; got ${RELEASE_TAG}"
+            exit 1
+          fi
+
+          version=${RELEASE_TAG#v}
+          chart_version=$(awk '$1 == "version:" {gsub(/"/, "", $2); print $2; exit}' charts/topograph/Chart.yaml)
+          app_version=$(awk '$1 == "appVersion:" {gsub(/"/, "", $2); print $2; exit}' charts/topograph/Chart.yaml)
+
+          if [[ "${chart_version}" != "${version}" ]]; then
+            echo "::error::Chart version ${chart_version} does not match release version ${version}."
+            exit 1
+          fi
+          if [[ "${app_version}" != "${RELEASE_TAG}" ]]; then
+            echo "::error::Chart appVersion ${app_version} does not match release tag ${RELEASE_TAG}."
+            exit 1
+          fi
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -47,23 +87,22 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
+          flavor: latest=false
           images: ${{ steps.image.outputs.name }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=ref,event=tag
             type=ref,event=branch
             type=sha,priority=100,prefix=,suffix=,format=short
 
       # Set up QEMU for cross-platform builds
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
           buildkitd-config: /etc/buildkit/buildkitd.toml
 
@@ -71,7 +110,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -2,6 +2,10 @@ name: Release Helm Charts
 
 on: workflow_dispatch
 
+concurrency:
+  group: helm-repository-publication
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: linux-amd64-cpu8
@@ -27,6 +31,15 @@ jobs:
           helm lint charts/topograph
           helm package charts/topograph --destination packaged
 
+      - name: Generate SHA-256 checksum
+        run: |
+          set -euo pipefail
+          cd packaged
+          for chart in topograph-*.tgz; do
+            sha256sum "${chart}" > "${chart}.sha256"
+            sha256sum --check "${chart}.sha256"
+          done
+
       - name: Generate SLSA provenance
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
@@ -34,8 +47,15 @@ jobs:
 
       - name: Fetch existing Helm repo index
         run: |
-          git fetch origin gh-pages || true
-          git checkout origin/gh-pages -- index.yaml || true
+          set -euo pipefail
+          if ! remote_ref=$(git ls-remote --heads origin refs/heads/gh-pages); then
+            echo "::error::Failed to check for the existing gh-pages branch."
+            exit 1
+          fi
+          if [[ -n "${remote_ref}" ]]; then
+            git fetch origin refs/heads/gh-pages:refs/remotes/origin/gh-pages
+            git checkout origin/gh-pages -- index.yaml
+          fi
 
       - name: Generate Helm repo index
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,159 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag (vX.Y.Z)
+        required: true
+        type: string
+
+concurrency:
+  group: helm-repository-publication
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  release:
+    name: Publish release
+    runs-on: linux-amd64-cpu8
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Validate release metadata
+        id: release
+        env:
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must match vX.Y.Z; got ${RELEASE_TAG}"
+            exit 1
+          fi
+
+          if [[ "${GITHUB_REF}" != "refs/tags/${RELEASE_TAG}" ]]; then
+            echo "::error::Run this workflow from tag ${RELEASE_TAG} so attestations identify the canonical tag."
+            echo "::error::Retry with: gh workflow run release.yml --ref ${RELEASE_TAG} -f tag=${RELEASE_TAG}"
+            exit 1
+          fi
+
+          tag_commit=$(git rev-parse "${RELEASE_TAG}^{commit}")
+          checkout_commit=$(git rev-parse HEAD)
+          if [[ "${tag_commit}" != "${checkout_commit}" ]]; then
+            echo "::error::Tag ${RELEASE_TAG} resolves to ${tag_commit}, but checkout is ${checkout_commit}."
+            exit 1
+          fi
+
+          version=${RELEASE_TAG#v}
+          chart_version=$(awk '$1 == "version:" {gsub(/"/, "", $2); print $2; exit}' charts/topograph/Chart.yaml)
+          app_version=$(awk '$1 == "appVersion:" {gsub(/"/, "", $2); print $2; exit}' charts/topograph/Chart.yaml)
+
+          if [[ "${chart_version}" != "${version}" ]]; then
+            echo "::error::Chart version ${chart_version} does not match release version ${version}."
+            exit 1
+          fi
+          if [[ "${app_version}" != "${RELEASE_TAG}" ]]; then
+            echo "::error::Chart appVersion ${app_version} does not match release tag ${RELEASE_TAG}."
+            exit 1
+          fi
+
+          awk -v heading="## [${version}]" '
+            index($0, heading) == 1 && (length($0) == length(heading) || substr($0, length(heading) + 1, 3) == " - ") {
+              found = 1
+              next
+            }
+            found && /^## / { exit }
+            found { print }
+            END { if (!found) exit 1 }
+          ' CHANGELOG.md > release-notes.md
+
+          if [[ ! -s release-notes.md ]] || ! grep -q '[^[:space:]]' release-notes.md; then
+            echo "::error::CHANGELOG.md has no release notes for ${version}."
+            exit 1
+          fi
+
+          echo "tag=${RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v3.14.0
+
+      - name: Package Helm chart
+        run: |
+          mkdir -p packaged
+          helm lint charts/topograph
+          helm package charts/topograph --destination packaged
+
+      - name: Generate SHA-256 checksum
+        env:
+          CHART: packaged/topograph-${{ steps.release.outputs.version }}.tgz
+        run: |
+          set -euo pipefail
+          cd "$(dirname "${CHART}")"
+          chart=$(basename "${CHART}")
+          sha256sum "${chart}" > "${chart}.sha256"
+          sha256sum --check "${chart}.sha256"
+
+      - name: Generate SLSA provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: packaged/topograph-${{ steps.release.outputs.version }}.tgz
+
+      - name: Fetch existing Helm repository index
+        run: |
+          set -euo pipefail
+          if ! remote_ref=$(git ls-remote --heads origin refs/heads/gh-pages); then
+            echo "::error::Failed to check for the existing gh-pages branch."
+            exit 1
+          fi
+          if [[ -n "${remote_ref}" ]]; then
+            git fetch origin refs/heads/gh-pages:refs/remotes/origin/gh-pages
+            git checkout origin/gh-pages -- index.yaml
+          fi
+
+      - name: Generate Helm repository index
+        run: |
+          if [[ -f index.yaml ]]; then
+            helm repo index packaged \
+              --url https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }} \
+              --merge index.yaml
+          else
+            helm repo index packaged \
+              --url https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+          fi
+
+      - name: Deploy Helm repository to GitHub Pages
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          keep_files: true
+          publish_branch: gh-pages
+          publish_dir: ./packaged
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          body_path: release-notes.md
+          files: |
+            packaged/topograph-${{ steps.release.outputs.version }}.tgz
+            packaged/topograph-${{ steps.release.outputs.version }}.tgz.sha256
+          prerelease: false
+          tag_name: ${{ steps.release.outputs.tag }}
+          name: ${{ steps.release.outputs.tag }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,8 +111,9 @@ Coverage checks run on pull requests. A drop below target with no matching uplif
 
 - `.github/workflows/go.yml` — build, test, lint, and `govulncheck` on every push and PR
 - `.github/workflows/chart-test.yaml` — Helm chart lint + helm-unittest suites (`make chart-test`) on every push and PR
-- `.github/workflows/docker.yml` — container image build (manual trigger)
-- `.github/workflows/helm-release.yaml` — Helm chart release (manual trigger)
+- `.github/workflows/docker.yml` — container image build on release tags or manual trigger
+- `.github/workflows/helm-release.yaml` — Helm chart release-candidate publication (manual trigger)
+- `.github/workflows/release.yml` — official tag-driven Helm, checksum, and GitHub Release publication
 
 ### Deployment surfaces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- SHA-256 checksum files published beside Helm chart packages and included
+  with their corresponding GitHub release assets.
+- Tag-driven official releases that publish the Helm chart, checksum, build
+  provenance, and GitHub release from the canonical release commit.
 - Signed SLSA build provenance for published container images and Helm chart
   packages. Release workflows bind each artifact to its source commit and
   workflow using GitHub artifact attestations; container provenance is also

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -74,7 +74,9 @@ Use one prerelease branch for all release candidates in a given release cycle.
 
    `https://nvidia.github.io/topograph/topograph-1.2.0-rc.1.tgz`
 
-   The workflow also generates signed SLSA provenance for the chart package.
+   The workflow also publishes
+   `topograph-1.2.0-rc.1.tgz.sha256` beside the chart package and generates
+   signed SLSA provenance for the chart package.
 
 6. Run the release-candidate test cycle.
 
@@ -112,22 +114,42 @@ When the release is ready for general availability, follow these steps:
    - Add or update the comparison link for the release.
 
 4. Run the [quality gates](#quality-gates), commit the changes with DCO
-   sign-off, push the branch, and create a pull request. Do not merge it yet.
+   sign-off, push the branch, and create a pull request.
 
-5. In GitHub Actions, run these workflows against the release branch:
+5. Merge the release pull request. Do not publish release artifacts from the
+   release branch; the canonical tag must identify the exact source commit used
+   to build them.
 
-   1. **Docker**
-   2. **Release Helm Charts**
+6. Update local `main`, record the release pull request's merge commit, verify
+   that it is on `main`, then create and push an annotated tag that targets that
+   exact commit. Replace `123` with the release pull request number and inspect
+   the displayed commit before pushing the tag:
 
-   Confirm that the container image and Helm chart were published successfully
-   and that both workflows generated SLSA provenance.
+   ```bash
+   git checkout main
+   git pull --ff-only origin main
+   RELEASE_PR=123
+   RELEASE_COMMIT=$(gh pr view "${RELEASE_PR}" --json mergeCommit --jq '.mergeCommit.oid')
+   if ! git merge-base --is-ancestor "${RELEASE_COMMIT}" origin/main; then
+     echo "Release commit is not reachable from origin/main." >&2
+     exit 1
+   fi
+   git show --no-patch --oneline "${RELEASE_COMMIT}"
+   git tag -a v1.2.0 "${RELEASE_COMMIT}" -m "Release v1.2.0"
+   git push origin v1.2.0
+   ```
 
-6. Merge the release pull request.
+7. The tag push automatically starts these workflows:
 
-7. On the [Topograph releases page](https://github.com/NVIDIA/topograph/releases),
-   draft and publish a release with the canonical version as both the tag and
-   release name, such as `v1.2.0`. Include the release notes from
-   `CHANGELOG.md`.
+   - **Release** packages and attests the Helm chart, generates and verifies its
+     SHA-256 checksum, publishes both files to the Helm repository, and creates
+     the GitHub release with both files attached.
+   - **Docker** publishes the multi-architecture container image and its signed
+     SLSA provenance.
+   - **Publish Fern Docs** publishes the versioned documentation.
+
+8. Complete the [release verification](#release-verification) after all three
+   workflows finish successfully.
 
 ## Workflow pipeline
 
@@ -144,15 +166,17 @@ flowchart TD
     I --> C
     G -->|Ready for GA| J[Release branch<br/>vX.Y.Z]
     J --> K[Quality gates<br/>and release PR]
-    K --> L[Docker and Helm<br/>artifacts and provenance]
-    L --> M[Merge release PR]
-    M --> N[GitHub release<br/>and vX.Y.Z tag]
-    N --> O[Publish Fern Docs<br/>versioned documentation]
+    K --> L[Merge release PR]
+    L --> M[Tag merged commit<br/>vX.Y.Z]
+    M --> N[Release workflow<br/>chart, checksum, provenance]
+    M --> O[Docker workflow<br/>image and provenance]
+    M --> P[Publish Fern Docs<br/>versioned documentation]
+    N --> Q[GitHub release]
 ```
 
-The **Docker** and **Release Helm Charts** workflows are manually dispatched by
-the nominated release person. Creating the release tag triggers the **Publish
-Fern Docs** workflow automatically.
+The nominated release person manually dispatches **Docker** and **Release Helm
+Charts** for release candidates. Pushing an official `vX.Y.Z` tag triggers the
+official **Release**, **Docker**, and **Publish Fern Docs** workflows.
 
 ## Released components
 
@@ -162,7 +186,9 @@ An official release publishes:
   `ghcr.io/nvidia/topograph:vX.Y.Z`
 - A Helm chart in the Topograph chart repository at
   `https://nvidia.github.io/topograph`
-- A GitHub release and source tag named `vX.Y.Z`
+- A SHA-256 checksum published beside the Helm chart package
+- A GitHub release and source tag named `vX.Y.Z`, with the Helm chart and its
+  checksum attached
 - Versioned documentation generated from the release tag
 - Signed SLSA build provenance for the container image and Helm chart package
 
@@ -199,24 +225,26 @@ Verify the container image's SLSA provenance:
 gh attestation verify oci://ghcr.io/nvidia/topograph:v1.2.0 \
   --repo NVIDIA/topograph \
   --signer-workflow NVIDIA/topograph/.github/workflows/docker.yml \
-  --source-ref refs/heads/v1.2.0
+  --source-ref refs/tags/v1.2.0
 ```
 
 Download the Helm chart and verify its SLSA provenance:
 
 ```bash
 curl -fsSLO https://nvidia.github.io/topograph/topograph-1.2.0.tgz
+curl -fsSLO https://nvidia.github.io/topograph/topograph-1.2.0.tgz.sha256
+sha256sum --check topograph-1.2.0.tgz.sha256
 gh attestation verify topograph-1.2.0.tgz \
   --repo NVIDIA/topograph \
-  --signer-workflow NVIDIA/topograph/.github/workflows/helm-release.yaml \
-  --source-ref refs/heads/v1.2.0
+  --signer-workflow NVIDIA/topograph/.github/workflows/release.yml \
+  --source-ref refs/tags/v1.2.0
 ```
 
 Also confirm that:
 
 - The [GitHub release](https://github.com/NVIDIA/topograph/releases) has the
-  correct tag and release notes.
-- The **Docker**, **Release Helm Charts**, and **Publish Fern Docs** workflow
+  correct tag, release notes, Helm chart, and checksum.
+- The **Docker**, **Release**, and **Publish Fern Docs** workflow
   runs completed successfully.
 - The published chart references the expected container image tag.
 
@@ -226,10 +254,20 @@ Also confirm that:
 
 - Review the failed workflow's logs in GitHub Actions.
 - Correct code or configuration through a reviewed pull request to `main`.
-- Update the release branch from `main`, rerun the quality gates, and retry the
-  failed workflow against the same release branch.
-- Do not publish the GitHub release until both the container image and Helm
-  chart have been verified.
+- Do not move or replace an existing release tag. If the release itself must be
+  corrected, prepare a new patch release.
+- To retry the **Release** workflow without changing its provenance context,
+  dispatch it from the existing tag:
+
+  ```bash
+  gh workflow run release.yml --ref v1.2.0 -f tag=v1.2.0
+  ```
+
+- To retry the **Docker** workflow, dispatch it from the same existing tag:
+
+  ```bash
+  gh workflow run docker.yml --ref v1.2.0
+  ```
 
 ### Failed documentation publication
 
@@ -248,5 +286,6 @@ Also confirm that:
 - For Helm provenance, confirm that the Helm job grants `id-token: write` and
   `attestations: write`. It does not need `artifact-metadata: write` because the
   chart attestation is stored by GitHub rather than pushed to an OCI registry.
-- Retry the failed publishing workflow against the same release branch after
-  correcting the failure.
+- Retry the failed publishing workflow from the same tag. For **Release**, use
+  the tag-bound manual dispatch command shown above so the new attestation still
+  names `refs/tags/v1.2.0` as its source.


### PR DESCRIPTION
Add a manually dispatched release workflow that validates the requested
version against Chart.yaml and CHANGELOG.md, creates the canonical Git tag,
and publishes the GitHub release as Latest.

Generate and verify SHA-256 checksums for Helm packages, attach the chart and
checksum to the GitHub release, and dispatch versioned Fern documentation
publishing explicitly.

Update the release procedure and changelog to document the automated flow.