### PR TITLE
fix(kwok-nodes): accept model basenames without the .yaml suffix

### DIFF
--- a/pkg/models/model_test.go
+++ b/pkg/models/model_test.go
@@ -21,6 +21,14 @@ func acceleratorDomainAnnotations(domain string) map[string]string {
 	return map[string]string{annotationAcceleratorDomain: domain}
 }
 
+func TestNewModelFromFileBasename(t *testing.T) {
+	for _, name := range []string{"small-tree", "small-tree.yaml"} {
+		cfg, err := NewModelFromFile(name)
+		require.NoError(t, err, name)
+		require.NotEmpty(t, cfg.Nodes, name)
+	}
+}
+
 func TestNewModelFromFileMedium(t *testing.T) {
 	cfg, err := NewModelFromFile("../../tests/models/medium.yaml")
 	require.NoError(t, err)

--- a/tests/model.go
+++ b/tests/model.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"embed"
 	"fmt"
+	"path/filepath"
 )
 
 const MODEL_FILE_PATTERN = "models/%s"
@@ -10,6 +11,10 @@ const MODEL_FILE_PATTERN = "models/%s"
 //go:embed models/*
 var modelFiles embed.FS
 
+// GetModelFileData reads an embedded model by basename; the .yaml suffix is optional.
 func GetModelFileData(fname string) ([]byte, error) {
+	if filepath.Ext(fname) == "" {
+		fname += ".yaml"
+	}
 	return modelFiles.ReadFile(fmt.Sprintf(MODEL_FILE_PATTERN, fname))
 }


### PR DESCRIPTION
Fixes #509

`kwok-nodes -model small-tree` fails with `open models/small-tree: file does not exist`, while the flag help says basenames resolve from `tests/models`. `GetModelFileData` now appends `.yaml` when the basename has no extension, so both the documented form and `small-tree.yaml` work. Paths with a directory component are unchanged.

Covered by a small test in `pkg/models` and checked with `./bin/kwok-nodes -model small-tree -output -`.
