### PR TITLE
docs(security): document supported versions, embargo, and artifact verification

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,7 +50,7 @@ which NVIDIA PSIRT operates. What to expect between your report and public discl
    coordinates that timing case by case. The
    [PSIRT policies page](https://www.nvidia.com/en-us/security/psirt-policies/) states that
    response timelines depend on the severity, the product affected, the current development
-   cycle, QA cycles, and whether the issue can only be fixed in a major release. This project
+   cycle, QA cycles, and whether the issue can only be updated in a major release. This project
    does not set a disclosure timeline of its own.
 3. **Pre-disclosure.** If a fix affects downstream consumers, PSIRT decides who is notified ahead
    of publication and what they are told. Please do not share details with third parties yourself

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,6 +68,12 @@ coordinated fix, possible.
 
 ## Verifying Release Artifacts
 
+This section applies to releases published after `v1.0.0`, the first ones cut by the release
+workflow that generates build provenance and a checksum file. `v1.0.0` and every earlier release
+predate that workflow: they publish the container image and the chart package only, with no
+attestation for either, no checksum file, and no assets on their GitHub release pages. That is
+expected for those releases, not a supply chain problem.
+
 An official release publishes a multi-architecture container image at
 `ghcr.io/nvidia/topograph:vX.Y.Z`, a Helm chart package in the chart repository at
 `https://nvidia.github.io/topograph`, and a SHA-256 checksum file beside the chart package. The
@@ -98,9 +104,10 @@ gh attestation verify topograph-X.Y.Z.tgz \
   --source-ref refs/tags/vX.Y.Z
 ```
 
-Treat a failed verification, a missing attestation, or an attestation naming a workflow or source
-reference other than the ones above as a potential supply chain problem, and report it through the
-channel described above.
+For a release covered by this section, treat a failed verification, a missing attestation, or an
+attestation naming a workflow or source reference other than the ones above as a potential supply
+chain problem, and report it through the channel described above. A release published before that
+point carries no attestation by design, so its absence is not something to report.
 
 Topograph does not currently publish a detached cosign signature or a GPG-signed release manifest.
 The Sigstore-backed provenance attestations and the chart checksum are the verification path

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,11 +45,13 @@ which NVIDIA PSIRT operates. What to expect between your report and public discl
    report; the Topograph maintainers develop the fix behind that channel.
 2. **Embargo.** The report stays under embargo while the fix is prepared. Please do not disclose
    the issue publicly, including in a GitHub issue, pull request, or discussion, in a conference
-   talk, or in a blog post, until a fix is available or PSIRT tells you the coordination deadline
-   has passed. PSIRT sets that deadline per report, based on severity, the work the fix requires,
-   and any coordination with other affected parties. Timelines are described on the
-   [PSIRT policies page](https://www.nvidia.com/en-us/security/psirt-policies/); this project
-   does not set a separate deadline of its own.
+   talk, or in a blog post, until NVIDIA has publicly released the update or mitigation
+   information for the issue, or PSIRT tells you that earlier disclosure is authorized. PSIRT
+   coordinates that timing case by case. The
+   [PSIRT policies page](https://www.nvidia.com/en-us/security/psirt-policies/) states that
+   response timelines depend on the severity, the product affected, the current development
+   cycle, QA cycles, and whether the issue can only be fixed in a major release. This project
+   does not set a disclosure timeline of its own.
 3. **Pre-disclosure.** If a fix affects downstream consumers, PSIRT decides who is notified ahead
    of publication and what they are told. Please do not share details with third parties yourself
    while the report is under embargo; ask PSIRT instead.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,22 @@ NVIDIA is dedicated to the security and trust of our software products and servi
 
 If you need to report a security issue, please use the appropriate contact points outlined below. **Please do not report security vulnerabilities through GitHub.** If a potential security issue is inadvertently reported via a public issue or pull request, NVIDIA maintainers may limit public discussion and redirect the reporter to the appropriate private disclosure channels.
 
+## Supported Versions
+
+Topograph uses semantic versions of the form `vMAJOR.MINOR.PATCH` and targets one minor release
+per calendar quarter. Security fixes are delivered as a new patch or minor release on the latest
+release line. They are not backported to earlier lines.
+
+| Version | Status |
+| --- | --- |
+| Latest minor release line (currently `v1.0.x`) | Supported. Receives security fixes. |
+| Any earlier minor release line, including all `v0.x` releases | Not supported. Upgrade to the latest release. |
+| `main` | Development branch. Fixes land here first, but it is not a supported release. |
+
+Operators are expected to track the latest release line. If you are running an older version,
+upgrade first and confirm the issue is still present before reporting it. How releases are cut
+and published is documented in [RELEASE.md](./RELEASE.md).
+
 ## Reporting Potential Security Vulnerability in an NVIDIA Product
 
 To report a potential security vulnerability in any NVIDIA product:
@@ -18,6 +34,75 @@ To report a potential security vulnerability in any NVIDIA product:
    	 - Potential impact of the vulnerability, including how an attacker could exploit the vulnerability
 
 While NVIDIA currently does not have a bug bounty program, we do offer acknowledgement when an externally reported security issue is addressed under our coordinated vulnerability disclosure policy. Please visit our [Product Security Incident Response Team (PSIRT)](https://www.nvidia.com/en-us/security/psirt-policies/) policies page for more information.
+
+## Embargo and Coordinated Disclosure
+
+Reports about Topograph are handled under NVIDIA's coordinated vulnerability disclosure policy,
+which NVIDIA PSIRT operates. What to expect between your report and public disclosure:
+
+1. **Acknowledgement and triage.** PSIRT confirms receipt, works to reproduce the issue, and
+   assesses its severity and the affected versions. PSIRT remains the point of contact for the
+   report; the Topograph maintainers develop the fix behind that channel.
+2. **Embargo.** The report stays under embargo while the fix is prepared. Please do not disclose
+   the issue publicly, including in a GitHub issue, pull request, or discussion, in a conference
+   talk, or in a blog post, until a fix is available or PSIRT tells you the coordination deadline
+   has passed. PSIRT sets that deadline per report, based on severity, the work the fix requires,
+   and any coordination with other affected parties. Timelines are described on the
+   [PSIRT policies page](https://www.nvidia.com/en-us/security/psirt-policies/); this project
+   does not set a separate deadline of its own.
+3. **Pre-disclosure.** If a fix affects downstream consumers, PSIRT decides who is notified ahead
+   of publication and what they are told. Please do not share details with third parties yourself
+   while the report is under embargo; ask PSIRT instead.
+4. **CVE assignment.** A CVE identifier for a confirmed vulnerability is assigned through NVIDIA
+   PSIRT, not through this repository.
+5. **Publication.** The fix ships in a release on a supported version line, as described in
+   [Supported Versions](#supported-versions), and the user-facing note is recorded under the
+   `### Security` heading in [CHANGELOG.md](./CHANGELOG.md). PSIRT determines whether a separate
+   NVIDIA security bulletin is published, and when.
+
+Acknowledgement for an externally reported issue is offered under that same policy, as stated
+above. Reporting privately and observing the embargo is what keeps that acknowledgement, and the
+coordinated fix, possible.
+
+## Verifying Release Artifacts
+
+An official release publishes a multi-architecture container image at
+`ghcr.io/nvidia/topograph:vX.Y.Z`, a Helm chart package in the chart repository at
+`https://nvidia.github.io/topograph`, and a SHA-256 checksum file beside the chart package. The
+chart package and its checksum are also attached to the GitHub release.
+
+The image and the chart package each carry SLSA build provenance produced by GitHub artifact
+attestations, which are signed through Sigstore. Verify what you downloaded before installing it,
+substituting the release you are checking for `vX.Y.Z` and `X.Y.Z`.
+
+Container image:
+
+```bash
+gh attestation verify oci://ghcr.io/nvidia/topograph:vX.Y.Z \
+  --repo NVIDIA/topograph \
+  --signer-workflow NVIDIA/topograph/.github/workflows/docker.yml \
+  --source-ref refs/tags/vX.Y.Z
+```
+
+Helm chart package and its checksum:
+
+```bash
+curl -fsSLO https://nvidia.github.io/topograph/topograph-X.Y.Z.tgz
+curl -fsSLO https://nvidia.github.io/topograph/topograph-X.Y.Z.tgz.sha256
+sha256sum --check topograph-X.Y.Z.tgz.sha256
+gh attestation verify topograph-X.Y.Z.tgz \
+  --repo NVIDIA/topograph \
+  --signer-workflow NVIDIA/topograph/.github/workflows/release.yml \
+  --source-ref refs/tags/vX.Y.Z
+```
+
+Treat a failed verification, a missing attestation, or an attestation naming a workflow or source
+reference other than the ones above as a potential supply chain problem, and report it through the
+channel described above.
+
+Topograph does not currently publish a detached cosign signature or a GPG-signed release manifest.
+The Sigstore-backed provenance attestations and the chart checksum are the verification path
+today. The full release and verification procedure is documented in [RELEASE.md](./RELEASE.md).
 
 ## NVIDIA Product Security
 


### PR DESCRIPTION
## Description

Adds a supported-versions matrix, an embargo and coordinated-disclosure section, and artifact
verification instructions to `SECURITY.md`.

Part of the OSS Health Scorecard work tracked in #513.

## What

- **Supported Versions**: which release line receives security fixes.
- **Embargo and Coordinated Disclosure**: what a reporter should expect between report and
  publication, including CVE assignment through PSIRT.
- **Verifying Release Artifacts**: how to check what you downloaded.

## The PSIRT routing is untouched

The diff is **94 insertions and 0 deletions**. That is the mechanical proof that the existing
reporting instructions survive byte for byte: `psirt@nvidia.com`, the submission form, the PGP
key, and the instruction not to report through GitHub are all unchanged and still appear
before the new material.

## Accuracy over completeness

The artifact section describes only what the release pipeline actually produces. A grep across
`.github/workflows/` for cosign, sigstore, gpg and attest returns only `attestations: write`
and three `actions/attest` steps, so the section covers GitHub artifact attestations signed
through Sigstore plus the chart SHA-256 checksum, and then says plainly that no detached
cosign signature or GPG-signed manifest is published today. Describing signing this project
does not do would be a false claim in a security document.

No response-time SLA was invented. The embargo section describes the process and points at the
published PSIRT policies page for timelines.

## Changed after review

Three corrections since the first round, all verified against the sources they cite:

1. **The embargo now matches the published PSIRT policy.** The section lifted the embargo once
   "a fix is available", which a merged commit or an unpublished build already satisfies. The
   cited policy page says a reporter is welcome to discuss publicly after an update or mitigation
   is *publicly released*. The file permitted disclosure the policy it cites does not.
2. **A per-report "deadline" mechanism was removed.** The section asserted that PSIRT sets a
   coordination deadline per report and cited that page as the source. The word does not appear
   on it; the page says response timelines depend on severity, the product affected, the
   development cycle, QA cycles, and whether the issue can only be updated in a major release.
   That framing replaced the invented mechanism.
3. **Artifact verification is now scoped to releases that carry provenance.** The section was
   written in the present tense, but the provenance workflow landed after `v1.0.0` was tagged, so
   for the only release that exists the image attestation, the chart checksum, the chart
   attestation, and the release assets are all absent. The section also told readers to treat a
   missing attestation as a potential supply chain problem and report it to PSIRT, which meant it
   routed every current user into filing a false report against a clean artifact. An opening
   clause now scopes the section and the reporting instruction no longer fires for a release that
   predates the workflow.

## Still open for a maintainer decision

`SECURITY.md` says security fixes are "not backported to earlier lines". `RELEASE.md` documents
long-lived `release-X.Y` branches and a flowchart edge for approved backports. Those two describe
different commitments. `RELEASE.md` says what the machinery permits; `SECURITY.md` says what the
project commits to, so they can coexist, but the wording is worth a deliberate choice rather than
leaving a reader to reconcile them. Not changed in this PR.

## For reviewers

The support matrix names the current release line explicitly, so it needs a one-line refresh
at each minor release. Say the word if you would rather it were expressed as a rule than a
table.

## Measured effect

Security Policy 2.60/4 to 2.80/4, plus two bonus signals. +1.85 points.

Documentation only.

Part of #513.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [ ] New or existing tests cover these changes. <!-- documentation only; no code path changes to cover -->
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).

