### PR TITLE
docs: correct package path, endpoint count, and authentication scope

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -56,7 +56,7 @@ ssl:
 
 ## API
 
-Topograph exposes three endpoints for interacting with the service. Below are the details of each endpoint:
+Topograph exposes five endpoints for interacting with the service. Below are the details of each endpoint:
 
 ### 1. Health Endpoint
 
@@ -171,3 +171,25 @@ id=$(curl -s -X POST -H "Content-Type: application/json" -d @payload.json http:/
 
 curl -s "http://localhost:49021/v1/topology?uid=$id"
 ```
+
+### 4. Topology Lookup Endpoint
+
+- **URL:** `POST http://<server>:<port>/v1/lookup`
+- **Description:** This endpoint retrieves the result of a topology request identified by its payload rather than by request ID. Topograph derives the request ID from the provider name and parameters and the engine name and parameters; credentials and the node list are not part of it. A client that still holds the payload can therefore read the result without storing the ID returned by the topology request endpoint. This endpoint never starts a new topology generation.
+- **Payload:** The same JSON object accepted by the topology request endpoint. Provider and engine names omitted from the payload fall back to the values in the Topograph config before the request ID is computed, exactly as they do for `/v1/generate`.
+- **Response:** The same status codes as the topology result endpoint:
+  - "200 OK" - The matching request has completed successfully, and the topology is returned in the body.
+  - "202 Accepted" - The matching request is still in progress.
+  - "404 Not Found" - No request with this payload has been submitted.
+  - Other error responses encountered by Topograph during request execution.
+
+Example usage:
+
+```bash
+curl -s -X POST -H "Content-Type: application/json" -d @payload.json http://localhost:49021/v1/lookup
+```
+
+### 5. Metrics Endpoint
+
+- **URL:** `GET http://<server>:<port>/metrics`
+- **Description:** This endpoint serves Prometheus metrics for the API server on the same port as the rest of the API. Exported metrics are `topograph_version`, `topograph_http_request_duration_seconds`, `topograph_request_duration_seconds`, `topograph_missing_topology`, and `topograph_validation_error_total`.

--- a/docs/engines/k8s.md
+++ b/docs/engines/k8s.md
@@ -291,7 +291,7 @@ A complete example values file is provided at `charts/topograph/values.k8s.gatew
 3. **A `Gateway` resource provisioned** with a listener this `HTTPRoute` can attach to. The chart does **not** author `Gateway` or `GatewayClass` resources — both are platform-owned.
 4. **A `ReferenceGrant`** in the Gateway's namespace if it lives in a different namespace from the release, per Gateway API cross-namespace attachment rules.
 
-**Default routing.** If `gatewayAPI.rules` is empty, the chart emits a single catch-all rule routing all requests to the Topograph Service (which serves `/v1/generate`, `/v1/topology`, `/healthz`, and `/metrics` on a single port). Override `gatewayAPI.rules` to provide path-specific matching — for example, to expose only `/v1/`:
+**Default routing.** If `gatewayAPI.rules` is empty, the chart emits a single catch-all rule routing all requests to the Topograph Service (which serves `/v1/generate`, `/v1/topology`, `/v1/lookup`, `/healthz`, and `/metrics` on a single port). Override `gatewayAPI.rules` to provide path-specific matching — for example, to expose only `/v1/`:
 
 ```yaml
 gatewayAPI:

--- a/docs/engines/k8s.md
+++ b/docs/engines/k8s.md
@@ -309,7 +309,7 @@ gatewayAPI:
           port: 49021
 ```
 
-**Authentication.** Topograph's binary has no built-in authentication on `/v1/generate`. When exposing the API externally, enforce authentication at the Gateway layer via the implementation's policy mechanism (kgateway `TrafficPolicy` + ExtAuth, Istio `RequestAuthentication`, Envoy Gateway `SecurityPolicy`, Nginx Gateway Fabric `ClientSettingsPolicy`, Cilium L7). These attach to the rendered `HTTPRoute` via `targetRefs` (or equivalent) as separate resources — no chart changes required. See `values.k8s.gateway-api-example.yaml` for a concrete kgateway example.
+**Authentication.** Topograph's binary has no built-in authentication on any endpoint, including `/v1/generate` and `/v1/lookup`. When exposing the API externally, enforce authentication at the Gateway layer via the implementation's policy mechanism (kgateway `TrafficPolicy` + ExtAuth, Istio `RequestAuthentication`, Envoy Gateway `SecurityPolicy`, Nginx Gateway Fabric `ClientSettingsPolicy`, Cilium L7). These attach to the rendered `HTTPRoute` via `targetRefs` (or equivalent) as separate resources — no chart changes required. See `values.k8s.gateway-api-example.yaml` for a concrete kgateway example.
 
 **GRPCRoute, TLSRoute, BackendTLSPolicy** are not supported in this chart. Topograph's API is HTTP-only; TLS termination (when needed) happens at the Gateway listener.
 

--- a/docs/get-started/quickstart-slurm.md
+++ b/docs/get-started/quickstart-slurm.md
@@ -16,17 +16,17 @@ Clone the repo and build a native package for your distribution:
 git clone https://github.com/NVIDIA/topograph.git
 cd topograph
 
-make deb        # Debian / Ubuntu — produces .deb under dist/
+make deb        # Debian / Ubuntu — produces .deb under bin/
 # or
-make rpm        # RHEL / Rocky / SUSE — produces .rpm under dist/
+make rpm        # RHEL / Rocky / SUSE — produces .rpm under bin/
 ```
 
 Install the resulting package:
 
 ```bash
-sudo dpkg -i dist/topograph_*.deb        # Debian / Ubuntu
+sudo dpkg -i bin/topograph-*.deb        # Debian / Ubuntu
 # or
-sudo rpm -ivh dist/topograph-*.rpm       # RHEL / Rocky / SUSE
+sudo rpm -ivh bin/topograph-*.rpm       # RHEL / Rocky / SUSE
 ```
 
 The package installs the service but does not start it. Edit `/etc/topograph/topograph-config.yaml` to set at minimum:


### PR DESCRIPTION
## Description

Corrects three factual errors in the documentation. No scorecard signal is involved; these are
simply wrong.

## 1. The Slurm quickstart points at a directory that does not exist

`docs/get-started/quickstart-slurm.md` told readers the packages land in `dist/` and to run
`dpkg -i dist/topograph_*.deb`. Both halves are wrong:

- `scripts/build-deb.sh:57` and `scripts/build-rpm.sh:37` default to `${REPO_HOME}/bin`
- `scripts/build-deb.sh:58` names the file `topograph-<ver>.<arch>.deb`, with a hyphen

`grep -rn 'dist/' Makefile scripts/` returns nothing. The documented glob therefore failed
twice over. Corrected to `bin/topograph-*.deb` and `bin/topograph-*.rpm`.

## 2. `docs/api.md` undercounted the endpoints

It said topograph exposes three endpoints. `initHttpServer` registers five: `/v1/generate`,
`/v1/topology`, `/v1/lookup`, `/healthz` and `/metrics`. The count is corrected and sections
for `/v1/lookup` and `/metrics` are added in the file's existing style, leaving the existing
sections numbered as they were.

Worth knowing, and now documented: `Request.Hash` hashes only provider name and params plus
engine name and params, so the `/v1/lookup` key is not the whole payload. Credentials and the
node list are excluded, which makes hits and misses surprising if you assume full-payload
matching.

## 3. The authentication note named only one endpoint

`docs/engines/k8s.md` said the binary has no built-in authentication on `/v1/generate`. True,
but incomplete in a way that matters now that `/v1/lookup` is documented as public: no handler
authenticates anything, so `/v1/lookup` is equally open and returns stored topology. An
operator could have read the old sentence literally and protected only `/v1/generate`.

The claim was verified before broadening it: the mux is a local variable with exactly five
registrations, nothing registers on `http.DefaultServeMux` repo-wide, `readRequest` and
`validate` inspect no credential, `LoggingMiddleware` never returns early, and there is no
mTLS anywhere. Each of those searches was positive-controlled so an empty result means real
absence.

The surrounding Gateway-layer guidance is unchanged; it already carries the remedy.

Documentation only.

Part of #513.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [ ] New or existing tests cover these changes. <!-- documentation only; no code path changes to cover -->
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
